### PR TITLE
gpio: rearrange GPIO module to use embedded-hal 1.0.0 traits; refactor for modern codestyle

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,9 @@ bare-metal = { version = "1.0.0" }
 cast = "0.3"
 cortex-m-rt = "0.7"
 critical-section = { version = "1.1.2" }
-embedded-hal = { version = "0.2", features = ["unproven"] }
+embedded-hal = "1.0.0"
+# For backward compatibility only. 
+embedded-hal-027 = { package = "embedded-hal", version = "0.2.7", features = ["unproven"] }
 embedded-hal-async = { version = "1.0" }
 embedded-io = "0.6.1"
 embedded-io-async = { version = "0.6.1", option = true }

--- a/examples/advanced_timer_block.rs
+++ b/examples/advanced_timer_block.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
 
-use embedded_hal_027::digital::v2::ToggleableOutputPin;
+use embedded_hal::digital::StatefulOutputPin;
 use hal::gpio::{Output, PinIoType, PinSpeed};
 use hal::mode::Blocking;
 use hal::timer::advanced_timer::AnyTimer;

--- a/examples/advanced_timer_block.rs
+++ b/examples/advanced_timer_block.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
 
-use embedded_hal::digital::v2::ToggleableOutputPin;
+use embedded_hal_027::digital::v2::ToggleableOutputPin;
 use hal::gpio::{Output, PinIoType, PinSpeed};
 use hal::mode::Blocking;
 use hal::timer::advanced_timer::AnyTimer;

--- a/examples/advanced_timer_block_2.rs
+++ b/examples/advanced_timer_block_2.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
 
-use embedded_hal::timer::CountDown;
+use embedded_hal_027::timer::CountDown;
 use fugit::ExtU32;
 use hal::mode::Blocking;
 use hal::timer::advanced_timer::AnyTimer;

--- a/examples/blinky.rs
+++ b/examples/blinky.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
 
-use embedded_hal::digital::v2::ToggleableOutputPin;
+use embedded_hal_027::digital::v2::ToggleableOutputPin;
 use hal::gpio::{Output, PinIoType, PinSpeed};
 use py32f030_hal as hal;
 

--- a/examples/blinky.rs
+++ b/examples/blinky.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
 
-use embedded_hal_027::digital::v2::ToggleableOutputPin;
+use embedded_hal::digital::StatefulOutputPin;
 use hal::gpio::{Output, PinIoType, PinSpeed};
 use py32f030_hal as hal;
 

--- a/examples/clock.rs
+++ b/examples/clock.rs
@@ -2,7 +2,7 @@
 #![no_main]
 
 use defmt_rtt as _;
-use embedded_hal_027::digital::v2::ToggleableOutputPin;
+use embedded_hal::digital::StatefulOutputPin;
 use panic_probe as _;
 
 use hal::clock::{self, Mco};

--- a/examples/clock.rs
+++ b/examples/clock.rs
@@ -2,7 +2,7 @@
 #![no_main]
 
 use defmt_rtt as _;
-use embedded_hal::digital::v2::ToggleableOutputPin;
+use embedded_hal_027::digital::v2::ToggleableOutputPin;
 use panic_probe as _;
 
 use hal::clock::{self, Mco};

--- a/examples/embassy_allpin.rs
+++ b/examples/embassy_allpin.rs
@@ -6,7 +6,7 @@
 
 use embassy_executor::Spawner;
 use embassy_time::Timer;
-use embedded_hal::digital::v2::ToggleableOutputPin;
+use embedded_hal_027::digital::v2::ToggleableOutputPin;
 use hal::gpio::{Output, PinIoType, PinSpeed};
 use py32f030_hal::{
     self as hal,

--- a/examples/embassy_allpin.rs
+++ b/examples/embassy_allpin.rs
@@ -6,7 +6,7 @@
 
 use embassy_executor::Spawner;
 use embassy_time::Timer;
-use embedded_hal_027::digital::v2::ToggleableOutputPin;
+use embedded_hal::digital::StatefulOutputPin;
 use hal::gpio::{Output, PinIoType, PinSpeed};
 use py32f030_hal::{
     self as hal,

--- a/examples/embassy_blinky.rs
+++ b/examples/embassy_blinky.rs
@@ -6,7 +6,7 @@
 
 use embassy_executor::Spawner;
 use embassy_time::Timer;
-use embedded_hal::digital::v2::ToggleableOutputPin;
+use embedded_hal_027::digital::v2::ToggleableOutputPin;
 use hal::gpio::{Output, PinIoType, PinSpeed};
 use py32f030_hal::{
     self as hal,

--- a/examples/embassy_blinky.rs
+++ b/examples/embassy_blinky.rs
@@ -6,7 +6,7 @@
 
 use embassy_executor::Spawner;
 use embassy_time::Timer;
-use embedded_hal_027::digital::v2::ToggleableOutputPin;
+use embedded_hal::digital::StatefulOutputPin;
 use hal::gpio::{Output, PinIoType, PinSpeed};
 use py32f030_hal::{
     self as hal,

--- a/examples/embassy_exit.rs
+++ b/examples/embassy_exit.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
 
-use embedded_hal::digital::v2::InputPin;
+use embedded_hal_027::digital::v2::InputPin;
 use hal::exti::ExtiInput;
 use hal::gpio::{PinPullUpDown, PinSpeed};
 use hal::mode::Async;

--- a/examples/embassy_exit.rs
+++ b/examples/embassy_exit.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
 
-use embedded_hal_027::digital::v2::InputPin;
+use embedded_hal::digital::InputPin;
 use hal::exti::ExtiInput;
 use hal::gpio::{PinPullUpDown, PinSpeed};
 use hal::mode::Async;
@@ -12,7 +12,7 @@ use embassy_executor::Spawner;
 use embassy_time::Timer;
 
 #[embassy_executor::task]
-async fn run(key: ExtiInput<'static, Async>) {
+async fn run(mut key: ExtiInput<'static, Async>) {
     loop {
         defmt::info!("wating for key push...");
         key.wait_for_low().await;

--- a/examples/embassy_i2c.rs
+++ b/examples/embassy_i2c.rs
@@ -2,7 +2,7 @@
 #![no_main]
 
 use defmt::Debug2Format;
-use embedded_hal_027::digital::v2::OutputPin;
+use embedded_hal::digital::OutputPin;
 use py32f030_hal::gpio::{Output, PinIoType, PinSpeed};
 use py32f030_hal::mode::Async;
 use py32f030_hal::{self as hal};

--- a/examples/embassy_i2c.rs
+++ b/examples/embassy_i2c.rs
@@ -2,7 +2,7 @@
 #![no_main]
 
 use defmt::Debug2Format;
-use embedded_hal::digital::v2::OutputPin;
+use embedded_hal_027::digital::v2::OutputPin;
 use py32f030_hal::gpio::{Output, PinIoType, PinSpeed};
 use py32f030_hal::mode::Async;
 use py32f030_hal::{self as hal};

--- a/examples/embassy_pwm.rs
+++ b/examples/embassy_pwm.rs
@@ -10,7 +10,7 @@ use py32f030_hal::{self as hal, mode::Blocking, timer::advanced_timer::Channel};
 use embassy_executor::Spawner;
 use embassy_time::Timer;
 // use hal::mcu::peripherals::TIM1;
-use embedded_hal::Pwm;
+use embedded_hal_027::Pwm;
 
 use {defmt_rtt as _, panic_probe as _};
 

--- a/examples/embassy_ssd1309.rs
+++ b/examples/embassy_ssd1309.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
 
-use embedded_hal::digital::v2::OutputPin;
+use embedded_hal_027::digital::v2::OutputPin;
 use py32f030_hal::gpio::{Output, PinIoType, PinSpeed};
 use py32f030_hal::mode::Blocking;
 

--- a/examples/embassy_ssd1309.rs
+++ b/examples/embassy_ssd1309.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #![no_main]
-
-use embedded_hal_027::digital::v2::OutputPin;
+use embedded_hal::digital::OutputPin;
 use py32f030_hal::gpio::{Output, PinIoType, PinSpeed};
 use py32f030_hal::mode::Blocking;
 

--- a/examples/i2c_master_block.rs
+++ b/examples/i2c_master_block.rs
@@ -3,7 +3,7 @@
 
 use defmt::Debug2Format;
 // use embedded_io::Write;
-use embedded_hal::digital::v2::OutputPin;
+use embedded_hal_027::digital::v2::OutputPin;
 use hal::delay;
 use hal::i2c::{AnyI2c, Config};
 use py32f030_hal::delay::delay_ms;

--- a/examples/i2c_master_block.rs
+++ b/examples/i2c_master_block.rs
@@ -3,7 +3,7 @@
 
 use defmt::Debug2Format;
 // use embedded_io::Write;
-use embedded_hal_027::digital::v2::OutputPin;
+use embedded_hal::digital::OutputPin;
 use hal::delay;
 use hal::i2c::{AnyI2c, Config};
 use py32f030_hal::delay::delay_ms;

--- a/examples/key.rs
+++ b/examples/key.rs
@@ -3,7 +3,7 @@
 
 use {defmt_rtt as _, panic_probe as _};
 
-use embedded_hal_027::digital::v2::InputPin;
+use embedded_hal::digital::InputPin;
 use hal::delay;
 use hal::gpio::{Input, PinPullUpDown, PinSpeed};
 use py32f030_hal as hal;
@@ -16,7 +16,7 @@ fn main() -> ! {
 
     let gpioa = p.GPIOF.split();
 
-    let key = Input::new(gpioa.PF4_BOOT0, PinPullUpDown::No, PinSpeed::Low);
+    let mut key = Input::new(gpioa.PF4_BOOT0, PinPullUpDown::No, PinSpeed::Low);
 
     loop {
         defmt::info!("key: {}", key.is_low());

--- a/examples/key.rs
+++ b/examples/key.rs
@@ -3,7 +3,7 @@
 
 use {defmt_rtt as _, panic_probe as _};
 
-use embedded_hal::digital::v2::InputPin;
+use embedded_hal_027::digital::v2::InputPin;
 use hal::delay;
 use hal::gpio::{Input, PinPullUpDown, PinSpeed};
 use py32f030_hal as hal;

--- a/examples/rtc_block.rs
+++ b/examples/rtc_block.rs
@@ -1,5 +1,5 @@
-///! #  RTC demo 
-///  该代码实现了一个RTC定时的功能
+//! #  RTC demo
+//!  该代码实现了一个RTC定时的功能
 #![no_std]
 #![no_main]
 

--- a/examples/timer3_block.rs
+++ b/examples/timer3_block.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
 
-use embedded_hal::timer::CountDown;
+use embedded_hal_027::timer::CountDown;
 use fugit::ExtU32;
 use hal::mode::Blocking;
 use hal::timer::general_purpose_timer::AnyTimer;

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -59,7 +59,7 @@ where
 //     }
 // }
 
-// impl embedded_hal::blocking::delay::DelayMs<usize> for Delay {
+// impl embedded_hal_027::blocking::delay::DelayMs<usize> for Delay {
 //     fn delay_ms(&mut self, _ms: usize) {
 //         delay(400)
 //     }

--- a/src/exti/mod.rs
+++ b/src/exti/mod.rs
@@ -124,6 +124,22 @@ impl<'d> ExtiInput<'d, Async> {
     }
 }
 
+impl<'a, M: Mode> embedded_hal::digital::ErrorType for ExtiInput<'a, M> {
+    type Error = core::convert::Infallible;
+}
+
+impl<'a, M: Mode> embedded_hal::digital::InputPin for ExtiInput<'a, M> {
+    #[inline]
+    fn is_low(&mut self) -> Result<bool, Self::Error> {
+        self.pin.is_low()
+    }
+
+    #[inline]
+    fn is_high(&mut self) -> Result<bool, Self::Error> {
+        self.pin.is_high()
+    }
+}
+
 impl<'a, M: Mode> embedded_hal_027::digital::v2::InputPin for ExtiInput<'a, M> {
     type Error = Infallible;
     fn is_low(&self) -> Result<bool, Self::Error> {

--- a/src/exti/mod.rs
+++ b/src/exti/mod.rs
@@ -124,7 +124,7 @@ impl<'d> ExtiInput<'d, Async> {
     }
 }
 
-impl<'a, M: Mode> embedded_hal::digital::v2::InputPin for ExtiInput<'a, M> {
+impl<'a, M: Mode> embedded_hal_027::digital::v2::InputPin for ExtiInput<'a, M> {
     type Error = Infallible;
     fn is_low(&self) -> Result<bool, Self::Error> {
         self.pin.is_low()

--- a/src/exti/mod.rs
+++ b/src/exti/mod.rs
@@ -57,7 +57,7 @@ impl<'d> ExtiInput<'d, Blocking> {
     /// 等待引脚电平变低
     #[inline]
     pub fn wait_for_low(&self) {
-        while self.get_level() == PinLevel::Hight {}
+        while self.get_level() == PinLevel::High {}
     }
 
     /// 等待引脚电平变高
@@ -101,7 +101,7 @@ impl<'d> ExtiInput<'d, Async> {
 
     /// 等待引脚电平变高
     pub async fn wait_for_high(&self) {
-        if self.get_level() == PinLevel::Hight {
+        if self.get_level() == PinLevel::High {
             return;
         }
         future::ExtiInputFuture::new(self.pin.pin.port(), self.pin.pin.pin(), Edge::Rising).await

--- a/src/exti/mod.rs
+++ b/src/exti/mod.rs
@@ -5,12 +5,13 @@ mod pins;
 mod types;
 
 use core::convert::Infallible;
+use embedded_hal::digital::PinState;
 
 pub use types::*;
 
 // use self::hal::sealed::Instance;
 use crate::gpio::Pin;
-use crate::gpio::{Input, PinLevel, PinPullUpDown, PinSpeed};
+use crate::gpio::{Input, PinPullUpDown, PinSpeed};
 #[cfg(feature = "embassy")]
 use crate::mode::Async;
 use crate::mode::{Blocking, Mode};
@@ -48,7 +49,7 @@ impl<'d, M: Mode> ExtiInput<'d, M> {
 
     /// 返回引脚的电平
     #[inline]
-    fn get_level(&self) -> PinLevel {
+    fn get_level(&self) -> PinState {
         self.pin.read()
     }
 }
@@ -57,13 +58,13 @@ impl<'d> ExtiInput<'d, Blocking> {
     /// 等待引脚电平变低
     #[inline]
     pub fn wait_for_low(&self) {
-        while self.get_level() == PinLevel::High {}
+        while self.get_level() == PinState::High {}
     }
 
     /// 等待引脚电平变高
     #[inline]
     pub fn wait_for_high(&self) {
-        while self.get_level() == PinLevel::Low {}
+        while self.get_level() == PinState::Low {}
     }
 
     /// 等待上升沿信号
@@ -92,7 +93,7 @@ impl<'d> ExtiInput<'d, Blocking> {
 impl<'d> ExtiInput<'d, Async> {
     /// 等待引脚电平变低
     pub async fn wait_for_low(&self) {
-        if self.get_level() == PinLevel::Low {
+        if self.get_level() == PinState::Low {
             return;
         }
 
@@ -101,7 +102,7 @@ impl<'d> ExtiInput<'d, Async> {
 
     /// 等待引脚电平变高
     pub async fn wait_for_high(&self) {
-        if self.get_level() == PinLevel::High {
+        if self.get_level() == PinState::High {
             return;
         }
         future::ExtiInputFuture::new(self.pin.pin.port(), self.pin.pin.pin(), Edge::Rising).await

--- a/src/gpio/hal.rs
+++ b/src/gpio/hal.rs
@@ -78,13 +78,16 @@ pub(crate) mod sealed {
         }
 
         #[inline]
-        fn read(&self) -> PinLevel {
+        fn read(&self) -> PinState {
             let r = self.block().idr.read().bits();
-            bit_mask_idx_get::<1>(self.pin(), r).into()
+            match bit_mask_idx_get::<1>(self.pin(), r) {
+                0 => PinState::Low,
+                _ => PinState::High,
+            }
         }
 
         #[inline]
-        fn write(&self, level: PinLevel) {
+        fn write(&self, level: PinState) {
             self.block().odr.modify(|r, w| unsafe {
                 w.bits(bit_mask_idx_modify::<1>(self.pin(), r.bits(), level as u32))
             })

--- a/src/gpio/mod.rs
+++ b/src/gpio/mod.rs
@@ -30,6 +30,7 @@
 pub(crate) mod hal;
 mod types;
 
+use embedded_hal::digital::PinState;
 use hal::*;
 
 pub use types::*;
@@ -184,13 +185,13 @@ impl<'d> Flex<'d> {
 
     /// Read the input electrical level of the current pin.
     #[inline]
-    pub fn read(&self) -> PinLevel {
+    pub fn read(&self) -> PinState {
         self.pin.read()
     }
 
     /// Write an output electrical level into the current pin.
     #[inline]
-    pub fn write(&self, level: PinLevel) {
+    pub fn write(&self, level: PinState) {
         self.pin.write(level)
     }
 }
@@ -243,7 +244,7 @@ impl<'d> Input<'d> {
 
     /// Read the input electrical level of the current pin.
     #[inline]
-    pub fn read(&self) -> PinLevel {
+    pub fn read(&self) -> PinState {
         self.pin.read()
     }
 }
@@ -265,13 +266,13 @@ impl<'d> Output<'d> {
 
     /// Read the input electrical level of the current pin.
     #[inline]
-    pub fn read(&self) -> PinLevel {
+    pub fn read(&self) -> PinState {
         self.pin.read()
     }
 
     /// Write an output electrical level into the current pin.
     #[inline]
-    pub fn write(&self, level: PinLevel) {
+    pub fn write(&self, level: PinState) {
         self.pin.write(level)
     }
 }
@@ -315,12 +316,12 @@ impl<'d> embedded_hal::digital::ErrorType for Input<'d> {
 impl<'d> embedded_hal::digital::InputPin for Input<'d> {
     #[inline]
     fn is_high(&mut self) -> Result<bool, Self::Error> {
-        Ok(self.read() == PinLevel::High)
+        Ok(self.read() == PinState::High)
     }
 
     #[inline]
     fn is_low(&mut self) -> Result<bool, Self::Error> {
-        Ok(self.read() == PinLevel::Low)
+        Ok(self.read() == PinState::Low)
     }
 }
 
@@ -331,13 +332,13 @@ impl<'d> embedded_hal::digital::ErrorType for Output<'d> {
 impl<'d> embedded_hal::digital::OutputPin for Output<'d> {
     #[inline]
     fn set_low(&mut self) -> Result<(), Self::Error> {
-        self.write(PinLevel::Low);
+        self.write(PinState::Low);
         Ok(())
     }
 
     #[inline]
     fn set_high(&mut self) -> Result<(), Self::Error> {
-        self.write(PinLevel::High);
+        self.write(PinState::High);
         Ok(())
     }
 }
@@ -345,12 +346,12 @@ impl<'d> embedded_hal::digital::OutputPin for Output<'d> {
 impl<'d> embedded_hal::digital::StatefulOutputPin for Output<'d> {
     #[inline]
     fn is_set_low(&mut self) -> Result<bool, Self::Error> {
-        Ok(self.read() == PinLevel::Low)
+        Ok(self.read() == PinState::Low)
     }
 
     #[inline]
     fn is_set_high(&mut self) -> Result<bool, Self::Error> {
-        Ok(self.read() == PinLevel::High)
+        Ok(self.read() == PinState::High)
     }
 
     #[inline]
@@ -367,25 +368,25 @@ impl<'d> embedded_hal::digital::ErrorType for Flex<'d> {
 impl<'d> embedded_hal::digital::InputPin for Flex<'d> {
     #[inline]
     fn is_low(&mut self) -> Result<bool, Self::Error> {
-        Ok(self.read() == PinLevel::Low)
+        Ok(self.read() == PinState::Low)
     }
 
     #[inline]
     fn is_high(&mut self) -> Result<bool, Self::Error> {
-        Ok(self.read() == PinLevel::High)
+        Ok(self.read() == PinState::High)
     }
 }
 
 impl<'d> embedded_hal::digital::OutputPin for Flex<'d> {
     #[inline]
     fn set_low(&mut self) -> Result<(), Self::Error> {
-        self.write(PinLevel::Low);
+        self.write(PinState::Low);
         Ok(())
     }
 
     #[inline]
     fn set_high(&mut self) -> Result<(), Self::Error> {
-        self.write(PinLevel::High);
+        self.write(PinState::High);
         Ok(())
     }
 }
@@ -393,12 +394,12 @@ impl<'d> embedded_hal::digital::OutputPin for Flex<'d> {
 impl<'d> embedded_hal::digital::StatefulOutputPin for Flex<'d> {
     #[inline]
     fn is_set_low(&mut self) -> Result<bool, Self::Error> {
-        Ok(self.read() == PinLevel::Low)
+        Ok(self.read() == PinState::Low)
     }
 
     #[inline]
     fn is_set_high(&mut self) -> Result<bool, Self::Error> {
-        Ok(self.read() == PinLevel::High)
+        Ok(self.read() == PinState::High)
     }
 
     #[inline]
@@ -409,17 +410,17 @@ impl<'d> embedded_hal::digital::StatefulOutputPin for Flex<'d> {
 }
 
 mod v027 {
-    use super::{Flex, Input, Output, PinLevel};
+    use super::{Flex, Input, Output, PinState};
     use core::convert::Infallible;
 
     impl<'d> embedded_hal_027::digital::v2::InputPin for Input<'d> {
         type Error = Infallible;
         fn is_low(&self) -> Result<bool, Self::Error> {
-            Ok(self.read() == PinLevel::Low)
+            Ok(self.read() == PinState::Low)
         }
 
         fn is_high(&self) -> Result<bool, Self::Error> {
-            Ok(self.read() == PinLevel::High)
+            Ok(self.read() == PinState::High)
         }
     }
 
@@ -427,23 +428,23 @@ mod v027 {
         type Error = Infallible;
 
         fn set_low(&mut self) -> Result<(), Self::Error> {
-            self.write(PinLevel::Low);
+            self.write(PinState::Low);
             Ok(())
         }
 
         fn set_high(&mut self) -> Result<(), Self::Error> {
-            self.write(PinLevel::High);
+            self.write(PinState::High);
             Ok(())
         }
     }
 
     impl<'d> embedded_hal_027::digital::v2::StatefulOutputPin for Output<'d> {
         fn is_set_low(&self) -> Result<bool, Self::Error> {
-            Ok(self.read() == PinLevel::Low)
+            Ok(self.read() == PinState::Low)
         }
 
         fn is_set_high(&self) -> Result<bool, Self::Error> {
-            Ok(self.read() == PinLevel::High)
+            Ok(self.read() == PinState::High)
         }
     }
 
@@ -458,11 +459,11 @@ mod v027 {
     impl<'d> embedded_hal_027::digital::v2::InputPin for Flex<'d> {
         type Error = Infallible;
         fn is_low(&self) -> Result<bool, Self::Error> {
-            Ok(self.read() == PinLevel::Low)
+            Ok(self.read() == PinState::Low)
         }
 
         fn is_high(&self) -> Result<bool, Self::Error> {
-            Ok(self.read() == PinLevel::High)
+            Ok(self.read() == PinState::High)
         }
     }
 
@@ -470,23 +471,23 @@ mod v027 {
         type Error = Infallible;
 
         fn set_low(&mut self) -> Result<(), Self::Error> {
-            self.write(PinLevel::Low);
+            self.write(PinState::Low);
             Ok(())
         }
 
         fn set_high(&mut self) -> Result<(), Self::Error> {
-            self.write(PinLevel::High);
+            self.write(PinState::High);
             Ok(())
         }
     }
 
     impl<'d> embedded_hal_027::digital::v2::StatefulOutputPin for Flex<'d> {
         fn is_set_low(&self) -> Result<bool, Self::Error> {
-            Ok(self.read() == PinLevel::Low)
+            Ok(self.read() == PinState::Low)
         }
 
         fn is_set_high(&self) -> Result<bool, Self::Error> {
-            Ok(self.read() == PinLevel::High)
+            Ok(self.read() == PinState::High)
         }
     }
 

--- a/src/gpio/mod.rs
+++ b/src/gpio/mod.rs
@@ -312,7 +312,7 @@ mod v2 {
     use super::{Flex, Input, Output, PinLevel};
     use core::convert::Infallible;
 
-    impl<'d> embedded_hal::digital::v2::InputPin for Input<'d> {
+    impl<'d> embedded_hal_027::digital::v2::InputPin for Input<'d> {
         type Error = Infallible;
         fn is_low(&self) -> Result<bool, Self::Error> {
             Ok(self.read() == PinLevel::Low)
@@ -323,7 +323,7 @@ mod v2 {
         }
     }
 
-    impl<'d> embedded_hal::digital::v2::OutputPin for Output<'d> {
+    impl<'d> embedded_hal_027::digital::v2::OutputPin for Output<'d> {
         type Error = Infallible;
 
         fn set_low(&mut self) -> Result<(), Self::Error> {
@@ -337,7 +337,7 @@ mod v2 {
         }
     }
 
-    impl<'d> embedded_hal::digital::v2::StatefulOutputPin for Output<'d> {
+    impl<'d> embedded_hal_027::digital::v2::StatefulOutputPin for Output<'d> {
         fn is_set_low(&self) -> Result<bool, Self::Error> {
             Ok(self.read() == PinLevel::Low)
         }
@@ -347,7 +347,7 @@ mod v2 {
         }
     }
 
-    impl<'d> embedded_hal::digital::v2::ToggleableOutputPin for Output<'d> {
+    impl<'d> embedded_hal_027::digital::v2::ToggleableOutputPin for Output<'d> {
         type Error = Infallible;
         fn toggle(&mut self) -> Result<(), Self::Error> {
             self.write(!(self.read()));
@@ -355,7 +355,7 @@ mod v2 {
         }
     }
 
-    impl<'d> embedded_hal::digital::v2::InputPin for Flex<'d> {
+    impl<'d> embedded_hal_027::digital::v2::InputPin for Flex<'d> {
         type Error = Infallible;
         fn is_low(&self) -> Result<bool, Self::Error> {
             Ok(self.read() == PinLevel::Low)
@@ -366,7 +366,7 @@ mod v2 {
         }
     }
 
-    impl<'d> embedded_hal::digital::v2::OutputPin for Flex<'d> {
+    impl<'d> embedded_hal_027::digital::v2::OutputPin for Flex<'d> {
         type Error = Infallible;
 
         fn set_low(&mut self) -> Result<(), Self::Error> {
@@ -380,7 +380,7 @@ mod v2 {
         }
     }
 
-    impl<'d> embedded_hal::digital::v2::StatefulOutputPin for Flex<'d> {
+    impl<'d> embedded_hal_027::digital::v2::StatefulOutputPin for Flex<'d> {
         fn is_set_low(&self) -> Result<bool, Self::Error> {
             Ok(self.read() == PinLevel::Low)
         }
@@ -390,7 +390,7 @@ mod v2 {
         }
     }
 
-    impl<'d> embedded_hal::digital::v2::ToggleableOutputPin for Flex<'d> {
+    impl<'d> embedded_hal_027::digital::v2::ToggleableOutputPin for Flex<'d> {
         type Error = Infallible;
         fn toggle(&mut self) -> Result<(), Self::Error> {
             self.write(!(self.read()));

--- a/src/gpio/mod.rs
+++ b/src/gpio/mod.rs
@@ -185,13 +185,13 @@ impl<'d> Flex<'d> {
 
     /// Read the input electrical level of the current pin.
     #[inline]
-    pub fn read(&self) -> PinState {
+    fn read(&self) -> PinState {
         self.pin.read()
     }
 
     /// Write an output electrical level into the current pin.
     #[inline]
-    pub fn write(&self, level: PinState) {
+    fn write(&self, level: PinState) {
         self.pin.write(level)
     }
 }
@@ -244,7 +244,7 @@ impl<'d> Input<'d> {
 
     /// Read the input electrical level of the current pin.
     #[inline]
-    pub fn read(&self) -> PinState {
+    pub(crate) fn read(&self) -> PinState {
         self.pin.read()
     }
 }
@@ -266,13 +266,13 @@ impl<'d> Output<'d> {
 
     /// Read the input electrical level of the current pin.
     #[inline]
-    pub fn read(&self) -> PinState {
+    fn read(&self) -> PinState {
         self.pin.read()
     }
 
     /// Write an output electrical level into the current pin.
     #[inline]
-    pub fn write(&self, level: PinState) {
+    fn write(&self, level: PinState) {
         self.pin.write(level)
     }
 }

--- a/src/gpio/mod.rs
+++ b/src/gpio/mod.rs
@@ -308,7 +308,107 @@ impl<'d> Analog<'d> {
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-mod v2 {
+impl<'d> embedded_hal::digital::ErrorType for Input<'d> {
+    type Error = core::convert::Infallible;
+}
+
+impl<'d> embedded_hal::digital::InputPin for Input<'d> {
+    #[inline]
+    fn is_high(&mut self) -> Result<bool, Self::Error> {
+        Ok(self.read() == PinLevel::High)
+    }
+
+    #[inline]
+    fn is_low(&mut self) -> Result<bool, Self::Error> {
+        Ok(self.read() == PinLevel::Low)
+    }
+}
+
+impl<'d> embedded_hal::digital::ErrorType for Output<'d> {
+    type Error = core::convert::Infallible;
+}
+
+impl<'d> embedded_hal::digital::OutputPin for Output<'d> {
+    #[inline]
+    fn set_low(&mut self) -> Result<(), Self::Error> {
+        self.write(PinLevel::Low);
+        Ok(())
+    }
+
+    #[inline]
+    fn set_high(&mut self) -> Result<(), Self::Error> {
+        self.write(PinLevel::High);
+        Ok(())
+    }
+}
+
+impl<'d> embedded_hal::digital::StatefulOutputPin for Output<'d> {
+    #[inline]
+    fn is_set_low(&mut self) -> Result<bool, Self::Error> {
+        Ok(self.read() == PinLevel::Low)
+    }
+
+    #[inline]
+    fn is_set_high(&mut self) -> Result<bool, Self::Error> {
+        Ok(self.read() == PinLevel::High)
+    }
+
+    #[inline]
+    fn toggle(&mut self) -> Result<(), Self::Error> {
+        self.write(!(self.read()));
+        Ok(())
+    }
+}
+
+impl<'d> embedded_hal::digital::ErrorType for Flex<'d> {
+    type Error = core::convert::Infallible;
+}
+
+impl<'d> embedded_hal::digital::InputPin for Flex<'d> {
+    #[inline]
+    fn is_low(&mut self) -> Result<bool, Self::Error> {
+        Ok(self.read() == PinLevel::Low)
+    }
+
+    #[inline]
+    fn is_high(&mut self) -> Result<bool, Self::Error> {
+        Ok(self.read() == PinLevel::High)
+    }
+}
+
+impl<'d> embedded_hal::digital::OutputPin for Flex<'d> {
+    #[inline]
+    fn set_low(&mut self) -> Result<(), Self::Error> {
+        self.write(PinLevel::Low);
+        Ok(())
+    }
+
+    #[inline]
+    fn set_high(&mut self) -> Result<(), Self::Error> {
+        self.write(PinLevel::High);
+        Ok(())
+    }
+}
+
+impl<'d> embedded_hal::digital::StatefulOutputPin for Flex<'d> {
+    #[inline]
+    fn is_set_low(&mut self) -> Result<bool, Self::Error> {
+        Ok(self.read() == PinLevel::Low)
+    }
+
+    #[inline]
+    fn is_set_high(&mut self) -> Result<bool, Self::Error> {
+        Ok(self.read() == PinLevel::High)
+    }
+
+    #[inline]
+    fn toggle(&mut self) -> Result<(), Self::Error> {
+        self.write(!(self.read()));
+        Ok(())
+    }
+}
+
+mod v027 {
     use super::{Flex, Input, Output, PinLevel};
     use core::convert::Infallible;
 
@@ -319,7 +419,7 @@ mod v2 {
         }
 
         fn is_high(&self) -> Result<bool, Self::Error> {
-            Ok(self.read() == PinLevel::Hight)
+            Ok(self.read() == PinLevel::High)
         }
     }
 
@@ -332,7 +432,7 @@ mod v2 {
         }
 
         fn set_high(&mut self) -> Result<(), Self::Error> {
-            self.write(PinLevel::Hight);
+            self.write(PinLevel::High);
             Ok(())
         }
     }
@@ -343,7 +443,7 @@ mod v2 {
         }
 
         fn is_set_high(&self) -> Result<bool, Self::Error> {
-            Ok(self.read() == PinLevel::Hight)
+            Ok(self.read() == PinLevel::High)
         }
     }
 
@@ -362,7 +462,7 @@ mod v2 {
         }
 
         fn is_high(&self) -> Result<bool, Self::Error> {
-            Ok(self.read() == PinLevel::Hight)
+            Ok(self.read() == PinLevel::High)
         }
     }
 
@@ -375,7 +475,7 @@ mod v2 {
         }
 
         fn set_high(&mut self) -> Result<(), Self::Error> {
-            self.write(PinLevel::Hight);
+            self.write(PinLevel::High);
             Ok(())
         }
     }
@@ -386,7 +486,7 @@ mod v2 {
         }
 
         fn is_set_high(&self) -> Result<bool, Self::Error> {
-            Ok(self.read() == PinLevel::Hight)
+            Ok(self.read() == PinLevel::High)
         }
     }
 

--- a/src/gpio/mod.rs
+++ b/src/gpio/mod.rs
@@ -85,6 +85,8 @@ impl Pin for AnyPin {
     }
 }
 
+/// Flexible GPIO pin.
+///
 /// Flex 接口的 pin
 /// 该结构体不对 api 调用做任何保护，例如引脚调用输出配置后，再读取，也许硬件不支持这种使用，但
 /// 这个对象依旧不阻止调用，如果希望更强的保护，推荐使用 `Input,Output,Analog` 等对象，保证
@@ -94,6 +96,7 @@ pub struct Flex<'d> {
 }
 
 pub trait Pin: Peripheral<P = Self> + Into<AnyPin> + sealed::Pin + Sized + 'static {
+    #[inline]
     fn degrade(self) -> AnyPin {
         AnyPin {
             port_pin: self.port_pin(),
@@ -112,15 +115,18 @@ impl<'d> Flex<'d> {
         }
     }
 
+    #[inline]
     pub fn port(&self) -> GpioPort {
         self.pin.port()
     }
 
+    #[inline]
     pub fn pin(&self) -> usize {
         self.pin.pin()
     }
 
-    /// 重新设置引脚为输入模式
+    /// Put the pin into input mode.
+    #[inline]
     pub fn set_as_input(&self, pull: PinPullUpDown, speed: PinSpeed) {
         critical_section::with(|_| {
             self.pin.set_mode(PinMode::Input);
@@ -129,7 +135,8 @@ impl<'d> Flex<'d> {
         });
     }
 
-    /// 重新设置引脚为输出模式
+    /// Put the pin into output mode.
+    #[inline]
     pub fn set_as_output(&self, io_type: PinIoType, speed: PinSpeed) {
         critical_section::with(|_| {
             self.pin.set_mode(PinMode::Output);
@@ -138,14 +145,16 @@ impl<'d> Flex<'d> {
         });
     }
 
-    /// 设置引脚为模拟引脚
+    /// Put the pin into analog mode.
+    #[inline]
     pub fn set_as_analog(&self) {
         critical_section::with(|_| {
             self.pin.set_mode(PinMode::Analog);
         });
     }
 
-    /// 设置引脚为外设功能模式
+    /// Put the pin into alternate function mode.
+    #[inline]
     pub fn set_as_af(&self, af: PinAF, speed: PinSpeed, io_type: PinIoType) {
         critical_section::with(|_| {
             self.pin.set_mode(PinMode::Af);
@@ -155,27 +164,32 @@ impl<'d> Flex<'d> {
         });
     }
 
-    /// 设置引脚上下拉配置
+    /// Set internal pull-up or pull-down configuration for this pin.
+    #[inline]
     pub fn set_push_pull(&self, push_pull: PinPullUpDown) {
         self.pin.set_push_pull(push_pull);
     }
 
-    /// 设置引脚的输出开漏配置
+    /// Set open-drain or push-pull output type for this pin.
+    #[inline]
     pub fn set_open_drain(&self, open_drain: PinOutputType) {
         self.pin.set_output_type(open_drain);
     }
 
-    /// 设置引脚的输入输出配置
+    /// Set the I/O type of current pin.
+    #[inline]
     pub fn set_io_type(&self, io_type: PinIoType) {
         self.pin.set_io_type(io_type)
     }
 
-    /// 引脚状态读取
+    /// Read the input electrical level of the current pin.
+    #[inline]
     pub fn read(&self) -> PinLevel {
         self.pin.read()
     }
 
-    /// 引脚状态写
+    /// Write an output electrical level into the current pin.
+    #[inline]
     pub fn write(&self, level: PinLevel) {
         self.pin.write(level)
     }
@@ -192,27 +206,29 @@ impl AnyPin {
     }
 }
 
-/// 输入类型的引脚
+/// Input-mode driver for a GPIO pin.
 pub struct Input<'d> {
     pub(crate) pin: Flex<'d>,
 }
 
-/// 输出类型的引脚
+/// Output-mode driver for a GPIO pin.
 pub struct Output<'d> {
     pub(crate) pin: Flex<'d>,
 }
 
-/// 功能复用类型的引脚
+/// Alternate function mode driver for a GPIO pin.
 pub struct Af<'d> {
     pub(crate) _pin: Flex<'d>,
 }
 
-/// 模拟引脚
+/// Analog-mode driver for a GPIO pin.
 pub struct Analog<'d> {
     pub(crate) _pin: Flex<'d>,
 }
 
 impl<'d> Input<'d> {
+    /// Create a GPIO input driver for a pin with the provided pull configuration.
+    #[inline]
     pub fn new(
         pin: impl Peripheral<P = impl Pin> + 'd,
         pull: PinPullUpDown,
@@ -225,14 +241,16 @@ impl<'d> Input<'d> {
         Self { pin }
     }
 
-    /// 读取引脚状态
+    /// Read the input electrical level of the current pin.
+    #[inline]
     pub fn read(&self) -> PinLevel {
         self.pin.read()
     }
 }
 
 impl<'d> Output<'d> {
-    /// 创建对象
+    /// Create a GPIO output driver for a pin with the provided I/O type and speed configurations.
+    #[inline]
     pub fn new(
         pin: impl Peripheral<P = impl Pin> + 'd,
         io_type: PinIoType,
@@ -245,19 +263,23 @@ impl<'d> Output<'d> {
         Self { pin }
     }
 
-    /// 读取引脚电平
+    /// Read the input electrical level of the current pin.
+    #[inline]
     pub fn read(&self) -> PinLevel {
         self.pin.read()
     }
 
-    /// 设置引脚电平
+    /// Write an output electrical level into the current pin.
+    #[inline]
     pub fn write(&self, level: PinLevel) {
         self.pin.write(level)
     }
 }
 
 impl<'d> Af<'d> {
-    /// 新建 AF 引脚
+    /// Create a GPIO alternate function driver for a pin with the provided alternate function,
+    /// I/O type and speed configurations.
+    #[inline]
     pub fn new(
         pin: impl Peripheral<P = impl Pin> + 'd,
         af: impl Into<PinAF>,
@@ -273,7 +295,8 @@ impl<'d> Af<'d> {
 }
 
 impl<'d> Analog<'d> {
-    /// 新建模拟引脚
+    /// Create a GPIO analog function driver for a pin.
+    #[inline]
     pub fn new(pin: impl Peripheral<P = impl Pin> + 'd) -> Self {
         let pin = Flex::new(pin);
 
@@ -285,7 +308,7 @@ impl<'d> Analog<'d> {
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-pub mod v2 {
+mod v2 {
     use super::{Flex, Input, Output, PinLevel};
     use core::convert::Infallible;
 

--- a/src/gpio/types.rs
+++ b/src/gpio/types.rs
@@ -1,5 +1,3 @@
-use core::ops::Not;
-
 /// Gpio Pin mode
 #[derive(Clone, Copy)]
 pub enum PinMode {
@@ -104,43 +102,6 @@ impl PinIoType {
 pub enum PinLock {
     Unlock = 0,
     Lock = 1,
-}
-
-/// Gpio io 电平
-#[derive(PartialEq, Eq, Clone, Copy)]
-pub enum PinLevel {
-    Low = 0,
-    High = 1,
-}
-
-impl Not for PinLevel {
-    type Output = Self;
-    #[inline]
-    fn not(self) -> Self::Output {
-        if self == Self::Low {
-            Self::High
-        } else {
-            Self::Low
-        }
-    }
-}
-
-impl From<u32> for PinLevel {
-    #[inline]
-    fn from(value: u32) -> Self {
-        match value {
-            0 => Self::Low,
-            1 => Self::High,
-            _ => unreachable!(),
-        }
-    }
-}
-
-impl From<PinLevel> for bool {
-    #[inline]
-    fn from(value: PinLevel) -> Self {
-        PinLevel::High == value
-    }
 }
 
 #[derive(Debug)]

--- a/src/gpio/types.rs
+++ b/src/gpio/types.rs
@@ -110,14 +110,15 @@ pub enum PinLock {
 #[derive(PartialEq, Eq, Clone, Copy)]
 pub enum PinLevel {
     Low = 0,
-    Hight = 1,
+    High = 1,
 }
 
 impl Not for PinLevel {
     type Output = Self;
+    #[inline]
     fn not(self) -> Self::Output {
         if self == Self::Low {
-            Self::Hight
+            Self::High
         } else {
             Self::Low
         }
@@ -125,18 +126,20 @@ impl Not for PinLevel {
 }
 
 impl From<u32> for PinLevel {
+    #[inline]
     fn from(value: u32) -> Self {
         match value {
             0 => Self::Low,
-            1 => Self::Hight,
+            1 => Self::High,
             _ => unreachable!(),
         }
     }
 }
 
 impl From<PinLevel> for bool {
+    #[inline]
     fn from(value: PinLevel) -> Self {
-        PinLevel::Hight == value
+        PinLevel::High == value
     }
 }
 

--- a/src/i2c/master.rs
+++ b/src/i2c/master.rs
@@ -118,7 +118,7 @@ impl<'d, T: Instance> Master<'d, T, Blocking> {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-impl<'d, T: Instance> embedded_hal::blocking::i2c::Write for Master<'d, T, Blocking> {
+impl<'d, T: Instance> embedded_hal_027::blocking::i2c::Write for Master<'d, T, Blocking> {
     type Error = Error;
     fn write(&mut self, address: u8, bytes: &[u8]) -> Result<(), Self::Error> {
         self.write_block(address, bytes)
@@ -126,7 +126,7 @@ impl<'d, T: Instance> embedded_hal::blocking::i2c::Write for Master<'d, T, Block
     }
 }
 
-impl<'d, T: Instance> embedded_hal::blocking::i2c::Read for Master<'d, T, Blocking> {
+impl<'d, T: Instance> embedded_hal_027::blocking::i2c::Read for Master<'d, T, Blocking> {
     type Error = Error;
     fn read(&mut self, address: u8, buffer: &mut [u8]) -> Result<(), Self::Error> {
         self.read_block(address, buffer)
@@ -134,7 +134,7 @@ impl<'d, T: Instance> embedded_hal::blocking::i2c::Read for Master<'d, T, Blocki
     }
 }
 
-impl<'d, T: Instance> embedded_hal::blocking::i2c::WriteRead for Master<'d, T, Blocking> {
+impl<'d, T: Instance> embedded_hal_027::blocking::i2c::WriteRead for Master<'d, T, Blocking> {
     type Error = Error;
     fn write_read(
         &mut self,

--- a/src/spi/mod.rs
+++ b/src/spi/mod.rs
@@ -12,7 +12,7 @@ use crate::mode::Mode;
 use core::marker::PhantomData;
 use embassy_hal_internal::{into_ref, Peripheral, PeripheralRef};
 
-use embedded_hal::spi;
+use embedded_hal_027::spi;
 use types::*;
 
 pub use master::Master;

--- a/src/timer/advanced_timer/counter.rs
+++ b/src/timer/advanced_timer/counter.rs
@@ -86,25 +86,25 @@ impl<'d, T: Instance> Counter<'d, T, Blocking> {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-impl<'d, T: Instance> embedded_hal::blocking::delay::DelayUs<u32> for Counter<'d, T, Blocking> {
+impl<'d, T: Instance> embedded_hal_027::blocking::delay::DelayUs<u32> for Counter<'d, T, Blocking> {
     fn delay_us(&mut self, us: u32) {
         self.delay_us_blocking(us)
     }
 }
 
-impl<'d, T: Instance> embedded_hal::blocking::delay::DelayMs<u32> for Counter<'d, T, Blocking> {
+impl<'d, T: Instance> embedded_hal_027::blocking::delay::DelayMs<u32> for Counter<'d, T, Blocking> {
     fn delay_ms(&mut self, ms: u32) {
         self.delay_us_blocking(ms * 1000);
     }
 }
 
-impl<'d, T: Instance> embedded_hal::blocking::delay::DelayMs<u8> for Counter<'d, T, Blocking> {
+impl<'d, T: Instance> embedded_hal_027::blocking::delay::DelayMs<u8> for Counter<'d, T, Blocking> {
     fn delay_ms(&mut self, ms: u8) {
         self.delay_us_blocking(ms as u32 * 1000);
     }
 }
 
-impl<'d, T: Instance> embedded_hal::timer::CountDown for Counter<'d, T, Blocking> {
+impl<'d, T: Instance> embedded_hal_027::timer::CountDown for Counter<'d, T, Blocking> {
     type Time = MicrosDurationU32;
     fn start<H>(&mut self, count: H)
     where

--- a/src/timer/advanced_timer/pwm.rs
+++ b/src/timer/advanced_timer/pwm.rs
@@ -275,7 +275,7 @@ impl<'d, T: Instance> Pwm<'d, T> {
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
-impl<'d, T: Instance> embedded_hal::Pwm for Pwm<'d, T> {
+impl<'d, T: Instance> embedded_hal_027::Pwm for Pwm<'d, T> {
     type Channel = Channel;
     type Duty = u16;
     type Time = u16;
@@ -312,7 +312,7 @@ impl<'d, T: Instance> embedded_hal::Pwm for Pwm<'d, T> {
     }
 }
 
-// impl<'d, T: Instance> embedded_hal::PwmPin for PwmChannel<'d, T> {
+// impl<'d, T: Instance> embedded_hal_027::PwmPin for PwmChannel<'d, T> {
 //     type Duty = u16;
 //     fn enable(&mut self) {
 //         todo!()

--- a/src/timer/general_purpose_timer/counter.rs
+++ b/src/timer/general_purpose_timer/counter.rs
@@ -85,25 +85,25 @@ impl<'d, T: Instance> Counter<'d, T, Blocking> {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-impl<'d, T: Instance> embedded_hal::blocking::delay::DelayUs<u32> for Counter<'d, T, Blocking> {
+impl<'d, T: Instance> embedded_hal_027::blocking::delay::DelayUs<u32> for Counter<'d, T, Blocking> {
     fn delay_us(&mut self, us: u32) {
         self.delay_us_blocking(us)
     }
 }
 
-impl<'d, T: Instance> embedded_hal::blocking::delay::DelayMs<u32> for Counter<'d, T, Blocking> {
+impl<'d, T: Instance> embedded_hal_027::blocking::delay::DelayMs<u32> for Counter<'d, T, Blocking> {
     fn delay_ms(&mut self, ms: u32) {
         self.delay_us_blocking(ms * 1000);
     }
 }
 
-impl<'d, T: Instance> embedded_hal::blocking::delay::DelayMs<u8> for Counter<'d, T, Blocking> {
+impl<'d, T: Instance> embedded_hal_027::blocking::delay::DelayMs<u8> for Counter<'d, T, Blocking> {
     fn delay_ms(&mut self, ms: u8) {
         self.delay_us_blocking(ms as u32 * 1000);
     }
 }
 
-impl<'d, T: Instance> embedded_hal::timer::CountDown for Counter<'d, T, Blocking> {
+impl<'d, T: Instance> embedded_hal_027::timer::CountDown for Counter<'d, T, Blocking> {
     type Time = MicrosDurationU32;
     fn start<H>(&mut self, count: H)
     where

--- a/src/timer/general_purpose_timer/pwm.rs
+++ b/src/timer/general_purpose_timer/pwm.rs
@@ -198,7 +198,7 @@ impl<'d, T: Instance> Pwm<'d, T> {
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
-impl<'d, T: Instance> embedded_hal::Pwm for Pwm<'d, T> {
+impl<'d, T: Instance> embedded_hal_027::Pwm for Pwm<'d, T> {
     type Channel = Channel;
     type Duty = u16;
     type Time = u16;
@@ -235,7 +235,7 @@ impl<'d, T: Instance> embedded_hal::Pwm for Pwm<'d, T> {
     }
 }
 
-// impl<'d, T: Instance> embedded_hal::PwmPin for PwmChannel<'d, T> {
+// impl<'d, T: Instance> embedded_hal_027::PwmPin for PwmChannel<'d, T> {
 //     type Duty = u16;
 //     fn enable(&mut self) {
 //         todo!()

--- a/src/usart/mod.rs
+++ b/src/usart/mod.rs
@@ -510,15 +510,15 @@ impl<'d, T: Instance, M: Mode> UsartTx<'d, T, M> {
     }
 }
 
-/// embedded_hal::serial for AnyUsart<'d, T, Blocking>
-impl<'d, T: Instance> embedded_hal::serial::Read<u8> for AnyUsart<'d, T, Blocking> {
+/// embedded_hal_027::serial for AnyUsart<'d, T, Blocking>
+impl<'d, T: Instance> embedded_hal_027::serial::Read<u8> for AnyUsart<'d, T, Blocking> {
     type Error = Error;
     fn read(&mut self) -> nb::Result<u8, Self::Error> {
         self.rx.nb_read()
     }
 }
 
-impl<'d, T: Instance> embedded_hal::serial::Write<u8> for AnyUsart<'d, T, Blocking> {
+impl<'d, T: Instance> embedded_hal_027::serial::Write<u8> for AnyUsart<'d, T, Blocking> {
     type Error = Error;
     fn flush(&mut self) -> nb::Result<(), Self::Error> {
         self.tx.flush()
@@ -529,16 +529,16 @@ impl<'d, T: Instance> embedded_hal::serial::Write<u8> for AnyUsart<'d, T, Blocki
     }
 }
 
-/// embedded_hal::serial for UsartRx<'d, T, Blocking>
-impl<'d, T: Instance> embedded_hal::serial::Read<u8> for UsartRx<'d, T, Blocking> {
+/// embedded_hal_027::serial for UsartRx<'d, T, Blocking>
+impl<'d, T: Instance> embedded_hal_027::serial::Read<u8> for UsartRx<'d, T, Blocking> {
     type Error = Error;
     fn read(&mut self) -> nb::Result<u8, Self::Error> {
         self.nb_read()
     }
 }
 
-/// embedded_hal::serial for UsartTx<'d, T, Blocking>
-impl<'d, T: Instance> embedded_hal::serial::Write<u8> for UsartTx<'d, T, Blocking> {
+/// embedded_hal_027::serial for UsartTx<'d, T, Blocking>
+impl<'d, T: Instance> embedded_hal_027::serial::Write<u8> for UsartTx<'d, T, Blocking> {
     type Error = Error;
     fn flush(&mut self) -> nb::Result<(), Self::Error> {
         T::tx_flush();


### PR DESCRIPTION
This pull request refactors the GPIO module and examples to align with embedded-hal 1.0.0 standards. The updates improve consistency, documentation, and usability for embedded developers. Key changes include:

## Changes in GPIO Implementation

- Embedded-HAL Digital Traits: Implemented `embedded-hal` 1.0.0 digital GPIO traits in the GPIO structures to enhance interoperability.
- Deprecated PinLevel: Replaced the custom `PinLevel` type with `PinState` from `embedded-hal`, reducing redundancy.
- Visibility Adjustments: Set read and write functions to private, encouraging users to adopt embedded-hal traits for interaction with GPIO structures.

## Example Updates

- Updated examples to utilize `embedded-hal` 1.0.0 digital GPIO traits, ensuring users have practical references for integration.

## Preparatory Steps for Transition

- Imported `embedded-hal` 0.2.7 as `embedded-hal-027` to maintain backward compatibility while transitioning to `embedded-hal` 1.0.0.

## Code Quality Improvements

- Added `#[inline]` annotations to enhance function performance.
- Improved documentation in English, including updates to example comments for clarity and conformity with Rust documentation conventions.

This refactor lays the groundwork for smoother adoption of the new embedded-hal version while maintaining compatibility and improving developer experience.