### PR TITLE
lib: refactor HAL modules and simplify examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ fugit-timer = "0.1.3"
 drop-move = "0.1.0"
 defmt-serial = "0.10.0"
 static_cell = "1"
+embedded-time = "0.12.1"
 
 [features]
 default = ["example", "embassy"] # "embassy"

--- a/examples/advanced_timer_block.rs
+++ b/examples/advanced_timer_block.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
 
-use hal::gpio::{Output, PinIoType, PinSpeed};
+use hal::gpio::{Output, PinIoType, Speed};
 use hal::mode::Blocking;
 use hal::timer::advanced_timer::AnyTimer;
 use py32f030_hal::{self as hal, prelude::*};
@@ -18,7 +18,7 @@ fn main() -> ! {
     let timer = AnyTimer::<_, Blocking>::new(p.TIM1).unwrap();
     let mut counter = timer.as_counter();
 
-    let mut led = Output::new(gpioa.PA0, PinIoType::PullUp, PinSpeed::Low);
+    let mut led = Output::new(gpioa.PA0, PinIoType::PullUp, Speed::Low);
 
     let mut cnt = 0;
 

--- a/examples/advanced_timer_block.rs
+++ b/examples/advanced_timer_block.rs
@@ -1,11 +1,10 @@
 #![no_std]
 #![no_main]
 
-use embedded_hal::digital::StatefulOutputPin;
 use hal::gpio::{Output, PinIoType, PinSpeed};
 use hal::mode::Blocking;
 use hal::timer::advanced_timer::AnyTimer;
-use py32f030_hal as hal;
+use py32f030_hal::{self as hal, prelude::*};
 
 use {defmt_rtt as _, panic_probe as _};
 

--- a/examples/blinky.rs
+++ b/examples/blinky.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
 
-use hal::gpio::{Output, PinIoType, PinSpeed};
+use hal::gpio::{Output, PinIoType, Speed};
 use py32f030_hal::{self as hal, prelude::*};
 
 use {defmt_rtt as _, panic_probe as _};
@@ -14,7 +14,7 @@ fn main() -> ! {
 
     let gpioa = p.GPIOA.split();
     // LED: RX led
-    let mut led = Output::new(gpioa.PA10, PinIoType::PullDown, PinSpeed::Low);
+    let mut led = Output::new(gpioa.PA10, PinIoType::PullDown, Speed::Low);
 
     loop {
         // 翻转led

--- a/examples/blinky.rs
+++ b/examples/blinky.rs
@@ -1,9 +1,8 @@
 #![no_std]
 #![no_main]
 
-use embedded_hal::digital::StatefulOutputPin;
 use hal::gpio::{Output, PinIoType, PinSpeed};
-use py32f030_hal as hal;
+use py32f030_hal::{self as hal, prelude::*};
 
 use {defmt_rtt as _, panic_probe as _};
 

--- a/examples/blinky.rs
+++ b/examples/blinky.rs
@@ -3,14 +3,13 @@
 
 use hal::gpio::{Output, PinIoType, Speed};
 use py32f030_hal::{self as hal, prelude::*};
-
-use {defmt_rtt as _, panic_probe as _};
+use {defmt::info, defmt_rtt as _, panic_probe as _};
 
 #[cortex_m_rt::entry]
 fn main() -> ! {
     let p = hal::init(Default::default());
 
-    defmt::info!("Led blinky testing...");
+    info!("Led blinky testing...");
 
     let gpioa = p.GPIOA.split();
     // LED: RX led

--- a/examples/block_uart.rs
+++ b/examples/block_uart.rs
@@ -1,13 +1,12 @@
 #![no_std]
 #![no_main]
 
-use defmt::Debug2Format;
-use embedded_io::{Read, Write};
+use defmt::{info, Debug2Format};
 use hal::dma::AnyDma;
 use hal::syscfg;
 use hal::usart::AnyUsart;
 use heapless::String;
-use py32f030_hal::{self as hal, mode::Blocking};
+use py32f030_hal::{self as hal, mode::Blocking, prelude::*};
 
 use {defmt_rtt as _, panic_probe as _};
 
@@ -36,7 +35,7 @@ fn main() -> ! {
 
     let (mut rx, mut tx) = usart.split();
 
-    defmt::info!("usart start...");
+    info!("usart start...");
     let buf: String<20> = "hello rust\r\n".into();
 
     let mut rx_buf: [u8; 10] = [0; 10];
@@ -44,11 +43,11 @@ fn main() -> ! {
     loop {
         // let cnt = rx.read_blocking(&mut rx_buf);
         let cnt = rx.read_dma_idle_blocking(&mut rx_buf).unwrap();
-        defmt::info!("recv: cnt: {} {}", Debug2Format(&cnt), rx_buf[0..cnt]);
+        info!("recv: cnt: {} {}", Debug2Format(&cnt), rx_buf[0..cnt]);
         // tx.write_bytes_blocking(&rx_buf);
 
         let cnt = rx.read_idle_blocking(&mut rx_buf);
-        defmt::info!("recv idle: cnt: {} {:x}", cnt, rx_buf[0..cnt]);
+        info!("recv idle: cnt: {} {:x}", cnt, rx_buf[0..cnt]);
 
         // // 使用标准接口来发送串口数据
         let _ = write!(tx, "example for usart\r\n");
@@ -57,7 +56,7 @@ fn main() -> ! {
         let _ = tx.write(&rx_buf[0..cnt]);
         let _ = tx.write(buf.as_bytes());
 
-        // defmt::info!("send: {} ", buf.as_bytes());
+        // info!("send: {} ", buf.as_bytes());
 
         // hal::delay::delay_ms(1000);
     }

--- a/examples/clock.rs
+++ b/examples/clock.rs
@@ -6,7 +6,7 @@ use panic_probe as _;
 
 use hal::clock::{self, Mco};
 use hal::gpio::{Af, PinAF};
-use py32f030_hal::gpio::{Output, PinIoType, PinSpeed};
+use py32f030_hal::gpio::{Output, PinIoType, Speed};
 use py32f030_hal::{self as hal, prelude::*};
 
 #[cortex_m_rt::entry]
@@ -15,15 +15,10 @@ fn main() -> ! {
     let p = hal::init(Default::default());
     let gpioa = p.GPIOA.split();
 
-    let _mco_pin = Af::new(
-        gpioa.PA1,
-        PinAF::AF15,
-        PinSpeed::VeryHigh,
-        PinIoType::PullUp,
-    );
+    let _mco_pin = Af::new(gpioa.PA1, PinAF::AF15, Speed::VeryHigh, PinIoType::PullUp);
     Mco::select(clock::McoSelect::SysClk, clock::McoDIV::DIV1);
 
-    let mut led = Output::new(gpioa.PA10, PinIoType::PullUp, PinSpeed::VeryHigh);
+    let mut led = Output::new(gpioa.PA10, PinIoType::PullUp, Speed::VeryHigh);
 
     cortex_m::asm::delay(1000 * 1000 * 5);
     // let _sysclk = clock::SysClock::<clock::HSIDiv<1>>::config().unwrap();

--- a/examples/clock.rs
+++ b/examples/clock.rs
@@ -1,17 +1,14 @@
 #![no_std]
 #![no_main]
 
-use defmt_rtt as _;
-use panic_probe as _;
-
 use hal::clock::{self, Mco};
-use hal::gpio::{Af, PinAF};
-use py32f030_hal::gpio::{Output, PinIoType, Speed};
+use py32f030_hal::gpio::{Af, Output, PinAF, PinIoType, Speed};
 use py32f030_hal::{self as hal, prelude::*};
+use {defmt::*, defmt_rtt as _, panic_probe as _};
 
 #[cortex_m_rt::entry]
 fn main() -> ! {
-    defmt::println!("examples: clock");
+    println!("examples: clock");
     let p = hal::init(Default::default());
     let gpioa = p.GPIOA.split();
 
@@ -30,11 +27,11 @@ fn main() -> ! {
     let _sysclk = clock::SysClock::<clock::PLL<clock::HSI>>::config().unwrap();
 
     cortex_m::asm::delay(1000 * 5);
-    defmt::info!("freq: {}MHZ", clock::sys_core_clock() / 1000 / 1000);
+    info!("freq: {}MHZ", clock::sys_core_clock() / 1000 / 1000);
 
     loop {
         cortex_m::asm::delay(1000 * 1000 * 10);
-        defmt::info!("8888");
+        info!("8888");
 
         let _ = led.toggle();
     }

--- a/examples/clock.rs
+++ b/examples/clock.rs
@@ -2,13 +2,12 @@
 #![no_main]
 
 use defmt_rtt as _;
-use embedded_hal::digital::StatefulOutputPin;
 use panic_probe as _;
 
 use hal::clock::{self, Mco};
 use hal::gpio::{Af, PinAF};
-use py32f030_hal as hal;
 use py32f030_hal::gpio::{Output, PinIoType, PinSpeed};
+use py32f030_hal::{self as hal, prelude::*};
 
 #[cortex_m_rt::entry]
 fn main() -> ! {

--- a/examples/crc.rs
+++ b/examples/crc.rs
@@ -2,10 +2,8 @@
 #![no_main]
 
 use embassy_executor::Spawner;
-use py32f030_hal::crc::Crc;
-use py32f030_hal::{self as hal};
-
-use {defmt_rtt as _, panic_probe as _};
+use py32f030_hal::{self as hal, crc::Crc};
+use {defmt::info, defmt_rtt as _, panic_probe as _};
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
@@ -35,12 +33,12 @@ async fn main(_spawner: Spawner) {
 
     assert_eq!(crc.calculate(&buf1), 0x379E9F06);
 
-    defmt::info!("{:x}", crc.calculate(&buf1));
+    info!("{:x}", crc.calculate(&buf1));
     crc.reset();
 
     crc.accumulat(&buf1[0..10]);
     let rst = crc.accumulat(&buf1[10..]);
-    defmt::info!("{:x}", rst);
+    info!("{:x}", rst);
 
     loop {
         cortex_m::asm::wfe();

--- a/examples/embassy_allpin.rs
+++ b/examples/embassy_allpin.rs
@@ -6,7 +6,7 @@
 
 use embassy_executor::Spawner;
 use embassy_time::Timer;
-use hal::gpio::{Output, PinIoType, PinSpeed};
+use hal::gpio::{Output, PinIoType, Speed};
 use py32f030_hal::{
     self as hal,
     gpio::{AnyPin, Pin},
@@ -17,7 +17,7 @@ use {defmt_rtt as _, panic_probe as _};
 
 #[embassy_executor::task(pool_size = 26)]
 async fn run_led(led: AnyPin, delay_ms: u64) {
-    let mut led = Output::new(led, PinIoType::PullDown, PinSpeed::Low);
+    let mut led = Output::new(led, PinIoType::PullDown, Speed::Low);
     loop {
         let _ = led.toggle();
         Timer::after_millis(delay_ms).await;

--- a/examples/embassy_allpin.rs
+++ b/examples/embassy_allpin.rs
@@ -6,11 +6,11 @@
 
 use embassy_executor::Spawner;
 use embassy_time::Timer;
-use embedded_hal::digital::StatefulOutputPin;
 use hal::gpio::{Output, PinIoType, PinSpeed};
 use py32f030_hal::{
     self as hal,
     gpio::{AnyPin, Pin},
+    prelude::*,
 };
 
 use {defmt_rtt as _, panic_probe as _};

--- a/examples/embassy_allpin.rs
+++ b/examples/embassy_allpin.rs
@@ -6,14 +6,9 @@
 
 use embassy_executor::Spawner;
 use embassy_time::Timer;
-use hal::gpio::{Output, PinIoType, Speed};
-use py32f030_hal::{
-    self as hal,
-    gpio::{AnyPin, Pin},
-    prelude::*,
-};
-
-use {defmt_rtt as _, panic_probe as _};
+use hal::gpio::{AnyPin, Output, PinIoType, Speed};
+use py32f030_hal::{self as hal, prelude::*};
+use {defmt::info, defmt_rtt as _, panic_probe as _};
 
 #[embassy_executor::task(pool_size = 26)]
 async fn run_led(led: AnyPin, delay_ms: u64) {
@@ -28,7 +23,7 @@ async fn run_led(led: AnyPin, delay_ms: u64) {
 async fn main(spawner: Spawner) {
     let p = hal::init(Default::default());
 
-    defmt::info!("Testing the flashing of different LEDs in multi-tasking.");
+    info!("Testing the flashing of different LEDs in multi-tasking.");
 
     let gpioa = p.GPIOA.split();
     let gpiob = p.GPIOB.split();

--- a/examples/embassy_blinky.rs
+++ b/examples/embassy_blinky.rs
@@ -6,7 +6,7 @@
 
 use embassy_executor::Spawner;
 use embassy_time::Timer;
-use hal::gpio::{Output, PinIoType, PinSpeed};
+use hal::gpio::{Output, PinIoType, Speed};
 use py32f030_hal::{
     self as hal,
     gpio::{AnyPin, Pin},
@@ -17,7 +17,7 @@ use {defmt_rtt as _, panic_probe as _};
 
 #[embassy_executor::task(pool_size = 2)]
 async fn run_led(led: AnyPin, delay_ms: u64) {
-    let mut led = Output::new(led, PinIoType::PullDown, PinSpeed::Low);
+    let mut led = Output::new(led, PinIoType::PullDown, Speed::Low);
     loop {
         let _ = led.toggle();
         Timer::after_millis(delay_ms).await;

--- a/examples/embassy_blinky.rs
+++ b/examples/embassy_blinky.rs
@@ -6,11 +6,11 @@
 
 use embassy_executor::Spawner;
 use embassy_time::Timer;
-use embedded_hal::digital::StatefulOutputPin;
 use hal::gpio::{Output, PinIoType, PinSpeed};
 use py32f030_hal::{
     self as hal,
     gpio::{AnyPin, Pin},
+    prelude::*,
 };
 
 use {defmt_rtt as _, panic_probe as _};

--- a/examples/embassy_blinky.rs
+++ b/examples/embassy_blinky.rs
@@ -6,13 +6,11 @@
 
 use embassy_executor::Spawner;
 use embassy_time::Timer;
-use hal::gpio::{Output, PinIoType, Speed};
 use py32f030_hal::{
     self as hal,
-    gpio::{AnyPin, Pin},
+    gpio::{AnyPin, Output, PinIoType, Speed},
     prelude::*,
 };
-
 use {defmt_rtt as _, panic_probe as _};
 
 #[embassy_executor::task(pool_size = 2)]

--- a/examples/embassy_delay.rs
+++ b/examples/embassy_delay.rs
@@ -1,11 +1,10 @@
 #![no_std]
 #![no_main]
 
-use py32f030_hal as hal;
-use {defmt_rtt as _, panic_probe as _};
-
 use embassy_executor::Spawner;
 use embassy_time::Timer;
+use py32f030_hal as hal;
+use {defmt::info, defmt_rtt as _, panic_probe as _};
 
 #[embassy_executor::task]
 async fn run() {
@@ -18,15 +17,15 @@ async fn run() {
 }
 
 #[embassy_executor::main]
-async fn main(_spawner: Spawner) {
+async fn main(spawner: Spawner) {
     let _p = hal::init(Default::default());
-    defmt::info!("Hello World!");
+    info!("Hello World!");
 
-    _spawner.spawn(run()).unwrap();
+    spawner.spawn(run()).unwrap();
 
     let mut cnt: u32 = 0;
     loop {
-        defmt::info!("high {} ", cnt);
+        info!("high {} ", cnt);
         cnt += 1;
         Timer::after_secs(5).await;
     }

--- a/examples/embassy_exit.rs
+++ b/examples/embassy_exit.rs
@@ -1,11 +1,10 @@
 #![no_std]
 #![no_main]
 
-use embedded_hal::digital::InputPin;
 use hal::exti::ExtiInput;
 use hal::gpio::{PinPullUpDown, PinSpeed};
 use hal::mode::Async;
-use py32f030_hal as hal;
+use py32f030_hal::{self as hal, prelude::*};
 use {defmt_rtt as _, panic_probe as _};
 
 use embassy_executor::Spawner;

--- a/examples/embassy_exit.rs
+++ b/examples/embassy_exit.rs
@@ -1,14 +1,13 @@
 #![no_std]
 #![no_main]
 
+use embassy_executor::Spawner;
+use embassy_time::Timer;
 use hal::exti::ExtiInput;
 use hal::gpio::{Pull, Speed};
 use hal::mode::Async;
 use py32f030_hal::{self as hal, prelude::*};
-use {defmt_rtt as _, panic_probe as _};
-
-use embassy_executor::Spawner;
-use embassy_time::Timer;
+use {defmt::info, defmt_rtt as _, panic_probe as _};
 
 #[embassy_executor::task]
 async fn run(mut key: ExtiInput<'static, Async>) {
@@ -22,18 +21,18 @@ async fn run(mut key: ExtiInput<'static, Async>) {
 }
 
 #[embassy_executor::main]
-async fn main(_spawner: Spawner) {
+async fn main(spawner: Spawner) {
     let p = hal::init(Default::default());
     let gpioa = p.GPIOF.split();
 
-    defmt::info!("Example: embassy exti!");
+    info!("Example: embassy exti!");
 
     let key: ExtiInput<_> = ExtiInput::new(gpioa.PF4_BOOT0, Pull::None, Speed::Low);
-    _spawner.spawn(run(key)).unwrap();
+    spawner.spawn(run(key)).unwrap();
 
     let mut cnt: u32 = 0;
     loop {
-        defmt::info!("high {} ", cnt);
+        info!("high {} ", cnt);
         cnt += 1;
         Timer::after_secs(5).await;
     }

--- a/examples/embassy_exit.rs
+++ b/examples/embassy_exit.rs
@@ -2,7 +2,7 @@
 #![no_main]
 
 use hal::exti::ExtiInput;
-use hal::gpio::{PinPullUpDown, PinSpeed};
+use hal::gpio::{Pull, Speed};
 use hal::mode::Async;
 use py32f030_hal::{self as hal, prelude::*};
 use {defmt_rtt as _, panic_probe as _};
@@ -28,7 +28,7 @@ async fn main(_spawner: Spawner) {
 
     defmt::info!("Example: embassy exti!");
 
-    let key: ExtiInput<_> = ExtiInput::new(gpioa.PF4_BOOT0, PinPullUpDown::No, PinSpeed::Low);
+    let key: ExtiInput<_> = ExtiInput::new(gpioa.PF4_BOOT0, Pull::None, Speed::Low);
     _spawner.spawn(run(key)).unwrap();
 
     let mut cnt: u32 = 0;

--- a/examples/embassy_i2c.rs
+++ b/examples/embassy_i2c.rs
@@ -2,7 +2,7 @@
 #![no_main]
 
 use defmt::Debug2Format;
-use py32f030_hal::gpio::{Output, PinIoType, PinSpeed};
+use py32f030_hal::gpio::{Output, PinIoType, Speed};
 use py32f030_hal::mode::Async;
 use py32f030_hal::{self as hal, prelude::*};
 
@@ -27,7 +27,7 @@ async fn main(_spawner: Spawner) {
 
     let gpioa = p.GPIOA.split();
 
-    let mut lcd_rst = Output::new(gpioa.PA4, PinIoType::PullUp, PinSpeed::Low);
+    let mut lcd_rst = Output::new(gpioa.PA4, PinIoType::PullUp, Speed::Low);
     let _ = lcd_rst.set_low();
 
     Timer::after_millis(1000).await;

--- a/examples/embassy_i2c.rs
+++ b/examples/embassy_i2c.rs
@@ -2,10 +2,9 @@
 #![no_main]
 
 use defmt::Debug2Format;
-use embedded_hal::digital::OutputPin;
 use py32f030_hal::gpio::{Output, PinIoType, PinSpeed};
 use py32f030_hal::mode::Async;
-use py32f030_hal::{self as hal};
+use py32f030_hal::{self as hal, prelude::*};
 
 use embassy_executor::Spawner;
 use embassy_time::Timer;

--- a/examples/embassy_ssd1309.rs
+++ b/examples/embassy_ssd1309.rs
@@ -1,10 +1,9 @@
 #![no_std]
 #![no_main]
-use embedded_hal::digital::OutputPin;
 use py32f030_hal::gpio::{Output, PinIoType, PinSpeed};
 use py32f030_hal::mode::Blocking;
 
-use py32f030_hal::{self as hal, clock};
+use py32f030_hal::{self as hal, clock, prelude::*};
 
 use embassy_executor::Spawner;
 use embassy_time::Timer;

--- a/examples/embassy_ssd1309.rs
+++ b/examples/embassy_ssd1309.rs
@@ -1,6 +1,6 @@
 #![no_std]
 #![no_main]
-use py32f030_hal::gpio::{Output, PinIoType, PinSpeed};
+use py32f030_hal::gpio::{Output, PinIoType, Speed};
 use py32f030_hal::mode::Blocking;
 
 use py32f030_hal::{self as hal, clock, prelude::*};
@@ -35,7 +35,7 @@ async fn main(_spawner: Spawner) {
 
     let gpioa = p.GPIOA.split();
 
-    let mut lcd_rst = Output::new(gpioa.PA4, PinIoType::PullUp, PinSpeed::Low);
+    let mut lcd_rst = Output::new(gpioa.PA4, PinIoType::PullUp, Speed::Low);
     let _ = lcd_rst.set_low();
 
     Timer::after_millis(1000).await;

--- a/examples/embassy_uart.rs
+++ b/examples/embassy_uart.rs
@@ -2,15 +2,12 @@
 #![no_main]
 
 // use embedded_io::Write;
-use defmt::Debug2Format;
-use hal::usart::AnyUsart;
-use heapless::String;
-use py32f030_hal::{self as hal, mode::Async};
-
-use {defmt_rtt as _, panic_probe as _};
-
+use defmt::{info, Debug2Format};
 use embassy_executor::Spawner;
 use embassy_time::Timer;
+use heapless::String;
+use py32f030_hal::{self as hal, usart::AnyUsart};
+use {defmt_rtt as _, panic_probe as _};
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
@@ -20,12 +17,11 @@ async fn main(_spawner: Spawner) {
     let rx = gpioa.PA10;
     let tx = gpioa.PA9;
 
-    let usart: AnyUsart<_, Async> =
-        AnyUsart::new(p.USART1, Some(rx), Some(tx), None, None, Default::default());
+    let usart = AnyUsart::new(p.USART1, Some(rx), Some(tx), None, None, Default::default());
 
     let (mut rx, mut tx) = usart.split();
 
-    defmt::info!("usart start...");
+    info!("usart start...");
     let buf: String<20> = "hello rust\r\n".into();
 
     let mut rx_buf: [u8; 10] = [0; 10];

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -2,12 +2,11 @@
 #![no_main]
 
 use py32f030_hal as _;
-
-use {defmt_rtt as _, panic_probe as _};
+use {defmt::info, defmt_rtt as _, panic_probe as _};
 
 #[cortex_m_rt::entry]
-fn main_fun() -> ! {
-    defmt::info!("hello world");
+fn main() -> ! {
+    info!("hello world");
     loop {
         cortex_m::asm::wfe();
     }

--- a/examples/i2c_master_block.rs
+++ b/examples/i2c_master_block.rs
@@ -3,12 +3,11 @@
 
 use defmt::Debug2Format;
 // use embedded_io::Write;
-use embedded_hal::digital::OutputPin;
 use hal::delay;
 use hal::i2c::{AnyI2c, Config};
 use py32f030_hal::delay::delay_ms;
 use py32f030_hal::gpio::{Output, PinIoType, PinSpeed};
-use py32f030_hal::{self as hal, mode::Blocking};
+use py32f030_hal::{self as hal, mode::Blocking, prelude::*};
 
 use {defmt_rtt as _, panic_probe as _};
 

--- a/examples/i2c_master_block.rs
+++ b/examples/i2c_master_block.rs
@@ -6,7 +6,7 @@ use defmt::Debug2Format;
 use hal::delay;
 use hal::i2c::{AnyI2c, Config};
 use py32f030_hal::delay::delay_ms;
-use py32f030_hal::gpio::{Output, PinIoType, PinSpeed};
+use py32f030_hal::gpio::{Output, PinIoType, Speed};
 use py32f030_hal::{self as hal, mode::Blocking, prelude::*};
 
 use {defmt_rtt as _, panic_probe as _};
@@ -18,7 +18,7 @@ fn main() -> ! {
 
     let gpioa = p.GPIOA.split();
 
-    let mut lcd_rst = Output::new(gpioa.PA4, PinIoType::PullUp, PinSpeed::Low);
+    let mut lcd_rst = Output::new(gpioa.PA4, PinIoType::PullUp, Speed::Low);
     let _ = lcd_rst.set_low();
     delay_ms(200);
     let _ = lcd_rst.set_high();

--- a/examples/key.rs
+++ b/examples/key.rs
@@ -4,7 +4,7 @@
 use {defmt_rtt as _, panic_probe as _};
 
 use hal::delay;
-use hal::gpio::{Input, PinPullUpDown, PinSpeed};
+use hal::gpio::{Input, Pull, Speed};
 use py32f030_hal::{self as hal, prelude::*};
 
 #[cortex_m_rt::entry]
@@ -15,7 +15,7 @@ fn main() -> ! {
 
     let gpioa = p.GPIOF.split();
 
-    let mut key = Input::new(gpioa.PF4_BOOT0, PinPullUpDown::No, PinSpeed::Low);
+    let mut key = Input::new(gpioa.PF4_BOOT0, Pull::None, Speed::Low);
 
     loop {
         defmt::info!("key: {}", key.is_low());

--- a/examples/key.rs
+++ b/examples/key.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
 
-use {defmt_rtt as _, panic_probe as _};
+use {defmt::*, defmt_rtt as _, panic_probe as _};
 
 use hal::delay;
 use hal::gpio::{Input, Pull, Speed};
@@ -9,7 +9,7 @@ use py32f030_hal::{self as hal, prelude::*};
 
 #[cortex_m_rt::entry]
 fn main() -> ! {
-    defmt::println!("examples: key");
+    println!("examples: key");
 
     let p = hal::init(Default::default());
 
@@ -18,7 +18,7 @@ fn main() -> ! {
     let mut key = Input::new(gpioa.PF4_BOOT0, Pull::None, Speed::Low);
 
     loop {
-        defmt::info!("key: {}", key.is_low());
+        info!("key: {}", key.is_low());
         delay::delay_ms(1000);
     }
 }

--- a/examples/key.rs
+++ b/examples/key.rs
@@ -3,10 +3,9 @@
 
 use {defmt_rtt as _, panic_probe as _};
 
-use embedded_hal::digital::InputPin;
 use hal::delay;
 use hal::gpio::{Input, PinPullUpDown, PinSpeed};
-use py32f030_hal as hal;
+use py32f030_hal::{self as hal, prelude::*};
 
 #[cortex_m_rt::entry]
 fn main() -> ! {

--- a/examples/uart.rs
+++ b/examples/uart.rs
@@ -1,12 +1,9 @@
 #![no_std]
 #![no_main]
 
-use embedded_io::Write;
-use hal::usart::AnyUsart;
 use heapless::String;
-use py32f030_hal as hal;
-
-use {defmt_rtt as _, panic_probe as _};
+use py32f030_hal::{self as hal, prelude::*, usart::AnyUsart};
+use {defmt::info, defmt_rtt as _, panic_probe as _};
 
 #[cortex_m_rt::entry]
 fn main() -> ! {
@@ -20,7 +17,7 @@ fn main() -> ! {
 
     let (_, mut tx) = usart.split();
 
-    defmt::info!("usart start...");
+    info!("usart start...");
     let buf: String<20> = "hello rust\r\n".into();
     loop {
         // 使用标准接口来发送串口数据
@@ -29,7 +26,7 @@ fn main() -> ! {
         // 使用自定义的驱动接口发送串口数据
         let _ = tx.write(buf.as_bytes());
 
-        defmt::info!("send: {} ", buf.as_bytes());
+        info!("send: {} ", buf.as_bytes());
         cortex_m::asm::delay(1000 * 1000 * 10);
     }
 }

--- a/examples/uart_defmt.rs
+++ b/examples/uart_defmt.rs
@@ -1,16 +1,14 @@
 #![no_std]
 #![no_main]
 
-use hal::mcu::peripherals::USART1;
-use hal::usart::AnyUsart;
-use py32f030_hal::{self as hal, mode::Blocking};
+use py32f030_hal::{self as hal, mcu::peripherals::USART1, mode::Blocking, usart::AnyUsart};
 use static_cell::StaticCell;
 
 static SERIAL: StaticCell<AnyUsart<'static, USART1, Blocking>> = StaticCell::new();
 
 // use defmt_rtt as _;
-use defmt_serial::{self as _};
 use panic_probe as _;
+use {defmt::info, defmt_serial as _};
 
 #[cortex_m_rt::entry]
 fn main() -> ! {
@@ -27,7 +25,7 @@ fn main() -> ! {
     let mut cnt = 0;
     loop {
         // https://github.com/gauteh/defmt-serial
-        defmt::info!("hello world {} {}", 123, cnt);
+        info!("hello world {} {}", 123, cnt);
         cnt += 1;
         cortex_m::asm::delay(1000 * 1000 * 10);
     }

--- a/src/exti/mod.rs
+++ b/src/exti/mod.rs
@@ -11,7 +11,7 @@ pub use types::*;
 
 // use self::hal::sealed::Instance;
 use crate::gpio::Pin;
-use crate::gpio::{Input, PinPullUpDown, PinSpeed};
+use crate::gpio::{Input, Pull, Speed};
 #[cfg(feature = "embassy")]
 use crate::mode::Async;
 use crate::mode::{Blocking, Mode};
@@ -34,11 +34,7 @@ pub struct ExtiInput<'d, M: Mode> {
 impl<'d, M: Mode> Unpin for ExtiInput<'d, M> {}
 
 impl<'d, M: Mode> ExtiInput<'d, M> {
-    pub fn new(
-        pin: impl Peripheral<P = impl Pin> + 'd,
-        pull: PinPullUpDown,
-        speed: PinSpeed,
-    ) -> Self {
+    pub fn new(pin: impl Peripheral<P = impl Pin> + 'd, pull: Pull, speed: Speed) -> Self {
         into_ref!(pin);
 
         Self {

--- a/src/gpio/hal.rs
+++ b/src/gpio/hal.rs
@@ -67,7 +67,7 @@ pub(crate) mod sealed {
         }
 
         #[inline]
-        fn set_push_pull(&self, push_pull: PinPullUpDown) {
+        fn set_push_pull(&self, push_pull: Pull) {
             self.block().pupdr.modify(|r, w| unsafe {
                 w.bits(bit_mask_idx_modify::<2>(
                     self.pin() * 2,
@@ -143,7 +143,7 @@ pub(crate) mod sealed {
         }
 
         #[inline]
-        fn set_speed(&self, speed: PinSpeed) {
+        fn set_speed(&self, speed: Speed) {
             self.block().ospeedr.modify(|r, w| unsafe {
                 w.bits(bit_mask_idx_modify::<2>(
                     self.pin() * 2,

--- a/src/gpio/mod.rs
+++ b/src/gpio/mod.rs
@@ -128,7 +128,7 @@ impl<'d> Flex<'d> {
 
     /// Put the pin into input mode.
     #[inline]
-    pub fn set_as_input(&self, pull: PinPullUpDown, speed: PinSpeed) {
+    pub fn set_as_input(&self, pull: Pull, speed: Speed) {
         critical_section::with(|_| {
             self.pin.set_mode(PinMode::Input);
             self.pin.set_push_pull(pull);
@@ -138,7 +138,7 @@ impl<'d> Flex<'d> {
 
     /// Put the pin into output mode.
     #[inline]
-    pub fn set_as_output(&self, io_type: PinIoType, speed: PinSpeed) {
+    pub fn set_as_output(&self, io_type: PinIoType, speed: Speed) {
         critical_section::with(|_| {
             self.pin.set_mode(PinMode::Output);
             self.pin.set_io_type(io_type);
@@ -156,7 +156,7 @@ impl<'d> Flex<'d> {
 
     /// Put the pin into alternate function mode.
     #[inline]
-    pub fn set_as_af(&self, af: PinAF, speed: PinSpeed, io_type: PinIoType) {
+    pub fn set_as_af(&self, af: PinAF, speed: Speed, io_type: PinIoType) {
         critical_section::with(|_| {
             self.pin.set_mode(PinMode::Af);
             self.pin.set_af(af);
@@ -167,7 +167,7 @@ impl<'d> Flex<'d> {
 
     /// Set internal pull-up or pull-down configuration for this pin.
     #[inline]
-    pub fn set_push_pull(&self, push_pull: PinPullUpDown) {
+    pub fn set_push_pull(&self, push_pull: Pull) {
         self.pin.set_push_pull(push_pull);
     }
 
@@ -230,11 +230,7 @@ pub struct Analog<'d> {
 impl<'d> Input<'d> {
     /// Create a GPIO input driver for a pin with the provided pull configuration.
     #[inline]
-    pub fn new(
-        pin: impl Peripheral<P = impl Pin> + 'd,
-        pull: PinPullUpDown,
-        speed: PinSpeed,
-    ) -> Self {
+    pub fn new(pin: impl Peripheral<P = impl Pin> + 'd, pull: Pull, speed: Speed) -> Self {
         let pin = Flex::new(pin);
 
         pin.set_as_input(pull, speed);
@@ -252,11 +248,7 @@ impl<'d> Input<'d> {
 impl<'d> Output<'d> {
     /// Create a GPIO output driver for a pin with the provided I/O type and speed configurations.
     #[inline]
-    pub fn new(
-        pin: impl Peripheral<P = impl Pin> + 'd,
-        io_type: PinIoType,
-        speed: PinSpeed,
-    ) -> Self {
+    pub fn new(pin: impl Peripheral<P = impl Pin> + 'd, io_type: PinIoType, speed: Speed) -> Self {
         let pin = Flex::new(pin);
 
         pin.set_as_output(io_type, speed);
@@ -284,7 +276,7 @@ impl<'d> Af<'d> {
     pub fn new(
         pin: impl Peripheral<P = impl Pin> + 'd,
         af: impl Into<PinAF>,
-        speed: PinSpeed,
+        speed: Speed,
         io_type: PinIoType,
     ) -> Self {
         let pin = Flex::new(pin);

--- a/src/gpio/types.rs
+++ b/src/gpio/types.rs
@@ -9,7 +9,7 @@ pub enum PinMode {
 
 /// Gpio Pin speed
 #[derive(Clone, Copy)]
-pub enum PinSpeed {
+pub enum Speed {
     VeryLow = 0,
     Low = 1,
     High = 2,
@@ -63,10 +63,10 @@ impl From<u32> for PinAF {
 
 /// Gpio pin 上下拉
 #[derive(Clone, Copy)]
-pub enum PinPullUpDown {
-    No = 0,
-    PullUp = 1,
-    PullDown = 2,
+pub enum Pull {
+    None = 0,
+    Up = 1,
+    Down = 2,
 }
 
 /// Gpio pin 输出类型
@@ -86,12 +86,12 @@ pub enum PinIoType {
 }
 
 impl PinIoType {
-    pub(crate) fn split(self) -> (PinPullUpDown, PinOutputType) {
+    pub(crate) fn split(self) -> (Pull, PinOutputType) {
         let (push_pull, output_type) = match self {
-            PinIoType::PullUp => (PinPullUpDown::PullUp, PinOutputType::PushPull),
-            PinIoType::PullDown => (PinPullUpDown::PullDown, PinOutputType::PushPull),
-            PinIoType::Floating => (PinPullUpDown::No, PinOutputType::PushPull),
-            PinIoType::OpenDrain => (PinPullUpDown::No, PinOutputType::OpenDrain),
+            PinIoType::PullUp => (Pull::Up, PinOutputType::PushPull),
+            PinIoType::PullDown => (Pull::Down, PinOutputType::PushPull),
+            PinIoType::Floating => (Pull::None, PinOutputType::PushPull),
+            PinIoType::OpenDrain => (Pull::None, PinOutputType::OpenDrain),
         };
         (push_pull, output_type)
     }

--- a/src/i2c/mod.rs
+++ b/src/i2c/mod.rs
@@ -103,8 +103,8 @@ impl<'d, T: Instance, M: Mode> AnyI2c<'d, T, M> {
 
         // od + pullup
         // 配置引脚功能为AF功能，开漏模式
-        scl.set_instance_af(gpio::PinSpeed::VeryHigh, gpio::PinIoType::OpenDrain);
-        sda.set_instance_af(gpio::PinSpeed::VeryHigh, gpio::PinIoType::OpenDrain);
+        scl.set_instance_af(gpio::Speed::VeryHigh, gpio::PinIoType::OpenDrain);
+        sda.set_instance_af(gpio::Speed::VeryHigh, gpio::PinIoType::OpenDrain);
 
         // 初始化
         Self::new_inner(config)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,9 @@ pub mod usart;
 
 #[doc(hidden)]
 pub mod prelude {
+    pub use crate::gpio::Pin as _;
     pub use embedded_hal::digital::{InputPin as _, OutputPin as _, StatefulOutputPin as _};
+    pub use embedded_io::{Read as _, Write as _};
 }
 
 pub mod config {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,11 @@ pub mod syscfg;
 pub mod timer;
 pub mod usart;
 
+#[doc(hidden)]
+pub mod prelude {
+    pub use embedded_hal::digital::{InputPin as _, OutputPin as _, StatefulOutputPin as _};
+}
+
 pub mod config {
 
     /// 系统时钟选择

--- a/src/macro_def.rs
+++ b/src/macro_def.rs
@@ -14,7 +14,7 @@ macro_rules! pin_af_for_instance_def {
 
             fn set_instance_af(
                 &self,
-                speed: $crate::gpio::PinSpeed,
+                speed: $crate::gpio::Speed,
                 io_type: $crate::gpio::PinIoType,
             ) {
                 self.set_mode($crate::gpio::PinMode::Af);

--- a/src/spi/mod.rs
+++ b/src/spi/mod.rs
@@ -7,7 +7,7 @@ use crate::clock::peripheral::{
     PeripheralClockIndex, PeripheralIdToClockIndex, PeripheralInterrupt,
 };
 use crate::gpio::AnyPin;
-use crate::gpio::{PinIoType, PinSpeed};
+use crate::gpio::{PinIoType, Speed};
 use crate::mode::Mode;
 use core::marker::PhantomData;
 use embassy_hal_internal::{into_ref, Peripheral, PeripheralRef};
@@ -104,7 +104,7 @@ impl<'d, T: Instance, M: Mode> AnySpi<'d, T, M> {
         into_ref!(sck);
 
         sck.set_instance_af(
-            PinSpeed::VeryHigh,
+            Speed::VeryHigh,
             if config.mode.polarity == spi::Polarity::IdleLow {
                 PinIoType::PullDown
             } else {
@@ -116,7 +116,7 @@ impl<'d, T: Instance, M: Mode> AnySpi<'d, T, M> {
             || None,
             |mosi| {
                 into_ref!(mosi);
-                mosi.set_instance_af(PinSpeed::VeryHigh, PinIoType::PullUp);
+                mosi.set_instance_af(Speed::VeryHigh, PinIoType::PullUp);
                 Some(mosi.map_into())
             },
         );
@@ -125,7 +125,7 @@ impl<'d, T: Instance, M: Mode> AnySpi<'d, T, M> {
             || None,
             |miso| {
                 into_ref!(miso);
-                miso.set_instance_af(PinSpeed::VeryHigh, PinIoType::OpenDrain);
+                miso.set_instance_af(Speed::VeryHigh, PinIoType::OpenDrain);
                 Some(miso.map_into())
             },
         );
@@ -139,7 +139,7 @@ impl<'d, T: Instance, M: Mode> AnySpi<'d, T, M> {
             },
             |nss| {
                 into_ref!(nss);
-                nss.set_instance_af(PinSpeed::VeryHigh, PinIoType::Floating);
+                nss.set_instance_af(Speed::VeryHigh, PinIoType::Floating);
                 Some(nss.map_into())
             },
         );

--- a/src/timer/advanced_timer/pwm.rs
+++ b/src/timer/advanced_timer/pwm.rs
@@ -119,7 +119,7 @@ impl<'d, T: Instance> Pwm<'d, T> {
             || None,
             |pin| {
                 into_ref!(pin);
-                pin.set_instance_af(gpio::PinSpeed::VeryHigh, gpio::PinIoType::PullUp);
+                pin.set_instance_af(gpio::Speed::VeryHigh, gpio::PinIoType::PullUp);
                 Some(pin.map_into())
             },
         );
@@ -128,7 +128,7 @@ impl<'d, T: Instance> Pwm<'d, T> {
             || None,
             |pin| {
                 into_ref!(pin);
-                pin.set_instance_af(gpio::PinSpeed::VeryHigh, gpio::PinIoType::PullUp);
+                pin.set_instance_af(gpio::Speed::VeryHigh, gpio::PinIoType::PullUp);
                 Some(pin.map_into())
             },
         );
@@ -149,7 +149,7 @@ impl<'d, T: Instance> Pwm<'d, T> {
             || None,
             |pin| {
                 into_ref!(pin);
-                pin.set_instance_af(gpio::PinSpeed::VeryHigh, gpio::PinIoType::PullUp);
+                pin.set_instance_af(gpio::Speed::VeryHigh, gpio::PinIoType::PullUp);
                 Some(pin.map_into())
             },
         );
@@ -158,7 +158,7 @@ impl<'d, T: Instance> Pwm<'d, T> {
             || None,
             |pin| {
                 into_ref!(pin);
-                pin.set_instance_af(gpio::PinSpeed::VeryHigh, gpio::PinIoType::PullUp);
+                pin.set_instance_af(gpio::Speed::VeryHigh, gpio::PinIoType::PullUp);
                 Some(pin.map_into())
             },
         );
@@ -179,7 +179,7 @@ impl<'d, T: Instance> Pwm<'d, T> {
             || None,
             |pin| {
                 into_ref!(pin);
-                pin.set_instance_af(gpio::PinSpeed::VeryHigh, gpio::PinIoType::PullUp);
+                pin.set_instance_af(gpio::Speed::VeryHigh, gpio::PinIoType::PullUp);
                 Some(pin.map_into())
             },
         );
@@ -188,7 +188,7 @@ impl<'d, T: Instance> Pwm<'d, T> {
             || None,
             |pin| {
                 into_ref!(pin);
-                pin.set_instance_af(gpio::PinSpeed::VeryHigh, gpio::PinIoType::PullUp);
+                pin.set_instance_af(gpio::Speed::VeryHigh, gpio::PinIoType::PullUp);
                 Some(pin.map_into())
             },
         );
@@ -205,7 +205,7 @@ impl<'d, T: Instance> Pwm<'d, T> {
             || None,
             |pin| {
                 into_ref!(pin);
-                pin.set_instance_af(gpio::PinSpeed::VeryHigh, gpio::PinIoType::PullUp);
+                pin.set_instance_af(gpio::Speed::VeryHigh, gpio::PinIoType::PullUp);
                 Some(pin.map_into())
             },
         );

--- a/src/timer/general_purpose_timer/pwm.rs
+++ b/src/timer/general_purpose_timer/pwm.rs
@@ -82,7 +82,7 @@ impl<'d, T: Instance> Pwm<'d, T> {
             || None,
             |pin| {
                 into_ref!(pin);
-                pin.set_instance_af(gpio::PinSpeed::VeryHigh, gpio::PinIoType::PullUp);
+                pin.set_instance_af(gpio::Speed::VeryHigh, gpio::PinIoType::PullUp);
                 Some(pin.map_into())
             },
         );
@@ -98,7 +98,7 @@ impl<'d, T: Instance> Pwm<'d, T> {
             || None,
             |pin| {
                 into_ref!(pin);
-                pin.set_instance_af(gpio::PinSpeed::VeryHigh, gpio::PinIoType::PullUp);
+                pin.set_instance_af(gpio::Speed::VeryHigh, gpio::PinIoType::PullUp);
                 Some(pin.map_into())
             },
         );
@@ -114,7 +114,7 @@ impl<'d, T: Instance> Pwm<'d, T> {
             || None,
             |pin| {
                 into_ref!(pin);
-                pin.set_instance_af(gpio::PinSpeed::VeryHigh, gpio::PinIoType::PullUp);
+                pin.set_instance_af(gpio::Speed::VeryHigh, gpio::PinIoType::PullUp);
                 Some(pin.map_into())
             },
         );
@@ -130,7 +130,7 @@ impl<'d, T: Instance> Pwm<'d, T> {
             || None,
             |pin| {
                 into_ref!(pin);
-                pin.set_instance_af(gpio::PinSpeed::VeryHigh, gpio::PinIoType::PullUp);
+                pin.set_instance_af(gpio::Speed::VeryHigh, gpio::PinIoType::PullUp);
                 Some(pin.map_into())
             },
         );

--- a/src/usart/hal.rs
+++ b/src/usart/hal.rs
@@ -2,7 +2,7 @@ pub mod sealed {
     use super::super::*;
     use crate::pac;
     use core::f32;
-    use core::intrinsics::floorf32;
+    use num_traits::float::FloatCore;
 
     pub trait Instance {
         fn id() -> Id;
@@ -274,9 +274,9 @@ pub mod sealed {
 
             // 设置波特率
             let over_sampling: u32 = config.over_sampling.div();
-            let div: f32 =
-                clock::sys_pclk() as f32 / (config.baud_rate as u32 * over_sampling) as f32;
-            let mantissa: u16 = unsafe { floorf32(div) } as u16;
+            let baud = config.baud_rate.0;
+            let div: f32 = clock::sys_pclk() as f32 / (baud * over_sampling) as f32;
+            let mantissa: u16 = div.floor() as u16;
             let fraction: u8 = (16.0 * (div - mantissa as f32)) as u8;
             block.brr.modify(|_, w| unsafe {
                 w.div_mantissa()

--- a/src/usart/mod.rs
+++ b/src/usart/mod.rs
@@ -147,7 +147,7 @@ impl<'d, T: Instance, M: Mode> AnyUsart<'d, T, M> {
             || None,
             |rxd| {
                 into_ref!(rxd);
-                rxd.set_instance_af(gpio::PinSpeed::VeryHigh, gpio::PinIoType::OpenDrain);
+                rxd.set_instance_af(gpio::Speed::VeryHigh, gpio::PinIoType::OpenDrain);
                 Some(rxd.map_into())
             },
         );
@@ -156,7 +156,7 @@ impl<'d, T: Instance, M: Mode> AnyUsart<'d, T, M> {
             || None,
             |txd| {
                 into_ref!(txd);
-                txd.set_instance_af(gpio::PinSpeed::VeryHigh, gpio::PinIoType::OpenDrain);
+                txd.set_instance_af(gpio::Speed::VeryHigh, gpio::PinIoType::OpenDrain);
                 Some(txd.map_into())
             },
         );

--- a/src/usart/mod.rs
+++ b/src/usart/mod.rs
@@ -37,19 +37,6 @@ pin_af_for_instance_def!(RxPin, Instance);
 pin_af_for_instance_def!(RtsPin, Instance);
 pin_af_for_instance_def!(CtsPin, Instance);
 
-/// 串口的综合配置结构体
-#[derive(Default)]
-pub struct Config {
-    pub baud_rate: BaudRate,
-    pub stop_bit: StopBits,
-    pub word_len: WordLen,
-    pub parity: Parity,
-    // pub hw_flow_ctrl: HwFlowCtrl,
-    pub data_bits: DataBits,
-    pub over_sampling: OverSampling,
-    // pub mode: T,
-}
-
 /// 串口号定义
 #[derive(Clone, Copy, PartialEq)]
 pub enum Id {

--- a/src/usart/types.rs
+++ b/src/usart/types.rs
@@ -1,3 +1,5 @@
+use embedded_time::rate::{Baud, Extensions};
+
 #[derive(Debug)]
 pub enum Error {
     StartTimeout,
@@ -11,28 +13,56 @@ pub enum Error {
     Others,
 }
 
-/// 串口停止位
-#[derive(Default)]
+/// Serial configuration structure.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct Config {
+    /// Serial baudrate.
+    pub baud_rate: Baud,
+    /// Number of stop bits.
+    pub stop_bit: StopBits,
+    /// Parity settings.
+    pub parity: Parity,
+    // pub hw_flow_ctrl: HwFlowCtrl,
+    /// Number of data bits.
+    pub data_bits: DataBits,
+    /// Oversampling type.
+    pub over_sampling: OverSampling,
+    // pub mode: T,
+}
+
+impl Default for Config {
+    /// Serial configuration defaults to 115200 Bd, 8-bit data, no parity check, 1 stop bit, oversampling by 16.
+    #[inline]
+    fn default() -> Self {
+        Self {
+            baud_rate: 115200.Bd(),
+            stop_bit: StopBits::One,
+            parity: Parity::None,
+            data_bits: DataBits::Eight,
+            over_sampling: OverSampling::Sixteen,
+        }
+    }
+}
+
+/// Number of stop bits.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Default)]
 pub enum StopBits {
+    /// 1 stop bit.
     #[default]
-    Stop1 = 0,
-    Stop2 = 1,
+    One = 0,
+    /// 2 stop bits.
+    Two = 1,
 }
 
-/// 串口数据长度
-#[derive(Default)]
-pub enum WordLen {
-    #[default]
-    WordLen8 = 0,
-    WordLen9 = 1,
-}
-
-/// 串口配置的校验位
-#[derive(Default, PartialEq)]
+/// Parity check type.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Default)]
 pub enum Parity {
+    /// No parity checks.
     #[default]
     None = 0,
+    /// Even parity check bit.
     Even = 1,
+    /// Odd parity check bit.
     Odd = 2,
 }
 
@@ -46,37 +76,19 @@ pub enum Parity {
 //     RtsCts = 3,
 // }
 
-/// 串口的波特率定义
-#[derive(Default)]
-pub enum BaudRate {
-    // Auto = 0,
-    Bps300 = 300,
-    Bps1200 = 1200,
-    Bps2400 = 2400,
-    Bps4800 = 4800,
-    Bps9600 = 9600,
-    Bps1440 = 1440,
-    Bps19200 = 19200,
-    Bps28800 = 28800,
-    Bps38400 = 38400,
-    Bps57600 = 57600,
-    Bps74880 = 74880,
-    #[default]
-    Bps115200 = 115200,
-    Bps230400 = 230400,
-}
-
-/// 串口时钟过采样配置
-#[derive(Default, Clone, Copy, PartialEq)]
+/// Clock oversampling settings.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Default)]
 pub enum OverSampling {
+    /// Oversampling by 16.
     #[default]
-    OverSampling16 = 0,
-    OverSampling8 = 1,
+    Sixteen = 0,
+    /// Oversampling by 8.
+    Eight = 1,
 }
 
 impl OverSampling {
     pub(crate) fn div(&self) -> u32 {
-        if *self == Self::OverSampling16 {
+        if *self == Self::Sixteen {
             16
         } else {
             8
@@ -86,20 +98,23 @@ impl OverSampling {
 
 impl From<OverSampling> for bool {
     fn from(value: OverSampling) -> Self {
-        value == OverSampling::OverSampling8
+        value == OverSampling::Eight
     }
 }
 
-/// 串口数据位定义
-#[derive(Default, PartialEq)]
+/// Number of data bits.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Default)]
 pub enum DataBits {
+    /// 8-bit data word.
     #[default]
-    DataBits8 = 0,
-    DataBits9 = 1,
+    Eight = 0,
+    /// 9-bit data word.
+    Nine = 1,
 }
 
 impl From<DataBits> for bool {
+    #[inline]
     fn from(value: DataBits) -> Self {
-        value == DataBits::DataBits9
+        value == DataBits::Nine
     }
 }


### PR DESCRIPTION
This pull request introduces significant improvements to the HAL crate by refining core module structures, renaming types for consistency, and enhancing example usability. The changes are as follows:

## Predefined Prelude Module:
- Added a prelude module to simplify use statements in examples. This reduces boilerplate and improves readability.
- Integrated the prelude module across all examples for consistency.

## USART Module Enhancements:
- Renamed and rearranged USART-related types, including StopBits, Parity, DataBits, Oversampling, and Config, to align with common naming conventions.
- Derived or implemented necessary traits for these types to improve usability and consistency.

## GPIO Module Improvements:
- Renamed pull and speed structures to Pull and Speed.
- Updated pull types to None, Up, and Down for better clarity and usability.

## Examples Refactoring:
- Included the prelude module in all examples and rearranged code for simplicity and better demonstration of usage patterns.

These updates enhance the overall maintainability, readability, and usability of the HAL crate while adhering to best practices in embedded development.