### PR TITLE
ci: create cargo fmt check and build examples github actions

### DIFF
--- a/.github/workflows/Cargo.yml
+++ b/.github/workflows/Cargo.yml
@@ -1,0 +1,45 @@
+name: Cargo
+
+on: [push, pull_request]
+
+env:
+  CARGO_TERM_COLOR: always
+  # By default, RUSTFLAGS with “-D warnings” turns “asm_const” warnings into errors.
+  RUSTFLAGS:
+
+jobs:
+  fmt:
+    name: Rustfmt all packages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: rustfmt
+      - name: Rustfmt Check
+        uses: actions-rust-lang/rustfmt@v1
+
+  build-py32f030-hal:
+    name: Build
+    needs: fmt
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        TARGET: [thumbv6m-none-eabi]
+        TOOLCHAIN: [nightly]
+        EXAMPLES: [adc_block, # adc_block_interrupt_closure,
+          advanced_timer_block,
+          advanced_timer_block_2, bit_test, blinky, block_uart, clock, crc,
+          dma_mem2mem, embassy_adc, embassy_allpin, embassy_blinky, embassy_delay,
+          embassy_dma_mem2mem, embassy_exit, embassy_i2c, embassy_iwdg, embassy_pwm,
+          embassy_rtc, embassy_ssd1309, embassy_uart, flash, hello_world,
+          i2c_master_block, key, rtc_block, timer3_block, timer3_pwm_block, uart,
+          uart_defmt]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          target: ${{ MATRIX.TARGET }}
+          toolchain: ${{ MATRIX.TOOLCHAIN }}
+      - name: Run build
+        run: cargo build --target ${{ MATRIX.TARGET }} --release --example ${{ MATRIX.EXAMPLES }}


### PR DESCRIPTION
In this pr, GitHub Actions' behavior conforms to the definition of this script. There are two jobs fmt and build-py32fo3o-hal.

- `cargo fmt --check`: format all packages on push and request.
- `build-py32f030-hal`: build a series of examples, such as `adc_block`, `adc_block_interrupt_closure`(exclude), `advanced_timer_block`, `advanced_timer_block_2, bit_test`, `blinky`, `block_uart`, `clock`, `crc`, `dma_mem2mem`, `embassy_adc`, `embassy_allpin`, `embassy_blinky`, `embassy_delay`, `embassy_dma_mem2mem`, `embassy_exit`,` embassy_i2c`, `embassy_iwdg`, `embassy_pwm`, `embassy_rtc`, `embassy_ssd1309`, `embassy_uart`, `flash`, `hello_world`, `i2c_master_block`, `key`, `rtc_block`, `timer3_block`, `timer3_pwm_block`, `uart`, `uart_defmt` by running the command `cargo build --target thumbv6m-none-eabi --release --example xxx`.

The GitHub Actions result are as follows:

![image](https://github.com/user-attachments/assets/5cf0b08d-2bb5-4d3a-bdf7-118bc1bda09c)

At last, I find an error running cargo build example:

```
error[E0599]: no method named `on_interrupt` found for struct `AnyAdc` in the current scope
  --> examples\adc_block_interrupt_closure.rs:49:9
   |
49 |     adc.on_interrupt(
   |     ----^^^^^^^^^^^^ method not found in `AnyAdc<'_, ADC, Blocking>`
```

Therefore, the example `adc_block_interrupt_closure` is excluded by `#`. If this issue is fixed, `#` can be removed.