### PR TITLE
deps: refactor I2C and SPI, update dependencies, and enhance CI for examples

### DIFF
--- a/.github/workflows/Cargo.yml
+++ b/.github/workflows/Cargo.yml
@@ -19,27 +19,17 @@ jobs:
       - name: Rustfmt Check
         uses: actions-rust-lang/rustfmt@v1
 
-  build-py32f030-hal:
-    name: Build
+  build:
+    name: Build examples
     needs: fmt
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        TARGET: [thumbv6m-none-eabi]
-        TOOLCHAIN: [nightly]
-        EXAMPLES: [adc_block, # adc_block_interrupt_closure,
-          advanced_timer_block,
-          advanced_timer_block_2, bit_test, blinky, block_uart, clock, crc,
-          dma_mem2mem, embassy_adc, embassy_allpin, embassy_blinky, embassy_delay,
-          embassy_dma_mem2mem, embassy_exit, embassy_i2c, embassy_iwdg, embassy_pwm,
-          embassy_rtc, embassy_ssd1309, embassy_uart, flash, hello_world,
-          i2c_master_block, key, rtc_block, timer3_block, timer3_pwm_block, uart,
-          uart_defmt]
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          target: ${{ MATRIX.TARGET }}
-          toolchain: ${{ MATRIX.TOOLCHAIN }}
-      - name: Run build
-        run: cargo build --target ${{ MATRIX.TARGET }} --release --example ${{ MATRIX.EXAMPLES }}
+          target: thumbv6m-none-eabi
+          toolchain: nightly
+      - name: Build under default features
+        run: cargo build --examples --target thumbv6m-none-eabi
+      # - name: Build under no embassy feature
+      #   run: cargo build --examples --no-default-features --target thumbv6m-none-eabi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ repository = "https://github.com/hysonglet/py32f030-hal"
 documentation = "https://docs.rs/py32f030-hal"
 readme = "README.md"
 
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -25,56 +24,24 @@ embedded-io = "0.6.1"
 embedded-io-async = { version = "0.6.1", option = true }
 nb = "1"
 void = { version = "1.0", default-features = false }
-panic-halt = { version = "0.2.0", optional = true }
-panic-probe = { version = "0.3", features = ["print-defmt"], optional = true }
-defmt = { version = "0.3.2", optional = true }
-defmt-rtt = { version = "0.4", optional = true }
-cortex-m = { version = "0.7.7", features = [
-    "critical-section-single-core",
-    "inline-asm",
-] }
+cortex-m = { version = "0.7.7", features = ["critical-section-single-core", "inline-asm"] }
 enumset = "1.1.3"
-alloc-cortex-m = "0.4.2"
 atomic-polyfill = "1.0.1"
 PY32f030xx-pac = { version = "0.1.0", features = ["rt"] }
 num-traits = { version = "0.2", default-features = false }
 heapless = "0.7"
-embassy-hal-internal = { version = "0.1.0", features = [
-    "cortex-m",
-    "prio-bits-3",
-] }
+embassy-hal-internal = { version = "0.1.0", features = ["cortex-m", "prio-bits-3"] }
 embassy-time-driver = { version = "0.1.0", default-features = false, optional = true }
 embassy-sync = { version = "0.5.0", optional = true }
-embassy-executor = { version = "0.5.0", optional = true, features = [
-    "arch-cortex-m",
-    "executor-thread",
-] }
-embassy-time = { version = "0.3.0", features = [
-    "generic-queue-16",
-], optional = true }
-embassy-futures = { version = "0.1.0" }
-# ssd1309 = {version = "0.4.0", optional = true}
-# display-interface = "^ 0.4"
-# embedded-graphics-core = { version = "^ 0.4", optional = true }
-# embedded-graphics = {version ="0.8.1", optional = true}
-display-interface = {version = "0.4.1", optional = true}
-# oled_async = "0.1.0-alpha1"
-embedded-graphics = "0.7.0"
-ssd1309 = "0.3.0"
-embedded-graphics-core = { version = "^ 0.3", optional = true }
-display-interface-i2c = "^ 0.4"
+embassy-time = { version = "0.3.0", features = ["generic-queue-16"], optional = true }
 fugit = { version = "0.3.6" }
 fugit-timer = "0.1.3"
 drop-move = "0.1.0"
-defmt-serial = "0.10.0"
-static_cell = "1"
 embedded-time = "0.12.1"
 
 [features]
-default = ["example", "embassy"] # "embassy"
-example = ["dep:defmt", "dep:defmt-rtt", "dep:panic-probe", "dep:panic-halt"]
+default = ["embassy"]
 embassy = [
-    "dep:embassy-executor",
     "dep:embassy-sync",
     "dep:embassy-time",
     "time-driver",
@@ -83,12 +50,36 @@ embassy = [
 time-driver = ["dep:embassy-time-driver", "embassy-time-driver/tick-hz-1_000"]
 
 [dev-dependencies]
+defmt = "0.3.2"
+defmt-rtt = "0.4"
+defmt-serial = "0.10.0"
+panic-halt = "0.2.0"
+panic-probe = { version = "0.3", features = ["print-defmt"] }
+ssd1309 = "0.3.0"
+# ssd1309 = { version = "0.4.0", optional = true }
+# display-interface = "^0.4"
+display-interface = "0.4.1"
+display-interface-i2c = "^0.4"
+# oled_async = "0.1.0-alpha.1"
+# embedded-graphics-core = { version = "^0.4", optional = true }
+# embedded-graphics = { version ="0.8.1", optional = true }
+embedded-graphics = "0.7.0"
+embedded-graphics-core = "^0.3"
+embassy-executor = { version = "0.5.0", features = ["arch-cortex-m", "executor-thread"] }
+embassy-futures = "0.1.0"
+alloc-cortex-m = "0.4.2"
+static_cell = "1"
 
 [[example]]
-name = "blinky"
+name = "embassy_adc"
+required-features = ["embassy"]
 
 [[example]]
-name = "embassy_uart"
+name = "embassy_allpin"
+required-features = ["embassy"]
+
+[[example]]
+name = "embassy_blinky"
 required-features = ["embassy"]
 
 [[example]]
@@ -96,10 +87,39 @@ name = "embassy_delay"
 required-features = ["embassy"]
 
 [[example]]
-name = "crc"
+name = "embassy_dma_mem2mem"
+required-features = ["embassy"]
 
 [[example]]
-name = "embassy_adc"
+name = "embassy_exit"
+required-features = ["embassy"]
+
+[[example]]
+name = "embassy_i2c"
+required-features = ["embassy"]
+
+[[example]]
+name = "embassy_iwdg"
+required-features = ["embassy"]
+
+[[example]]
+name = "embassy_pwm"
+required-features = ["embassy"]
+
+[[example]]
+name = "embassy_rtc"
+required-features = ["embassy"]
+
+[[example]]
+name = "embassy_ssd1309"
+required-features = ["embassy"]
+
+[[example]]
+name = "embassy_uart"
+required-features = ["embassy"]
+
+[[example]]
+name = "crc"
 required-features = ["embassy"]
 
 [profile.dev]

--- a/examples/adc_block_interrupt_closure.rs
+++ b/examples/adc_block_interrupt_closure.rs
@@ -46,6 +46,8 @@ fn main() -> ! {
     // 使用闭包的方式在中断中调用闭包处理函数
     // 兼顾友好型 api
     static mut QUEUE: [u16; 16] = [0; 16];
+    // Ensure this example builds under compile configurations with embassy feature
+    #[cfg(not(feature = "embassy"))]
     adc.on_interrupt(
         Event::EOC.into(), /* EOC 中断 */
         alloc::boxed::Box::new(move |adc| {

--- a/src/spi/hal.rs
+++ b/src/spi/hal.rs
@@ -87,19 +87,19 @@ pub(super) mod sealed {
 
         /// Clock polarity
         #[inline]
-        fn set_clock_polarity(polarity: ClockPolarity) {
+        fn set_clock_polarity(polarity: embedded_hal::spi::Polarity) {
             // This bit should not be changed when communication is ongoing
             Self::block()
                 .cr1
-                .modify(|_, w| w.cpol().bit(polarity == ClockPolarity::Hight))
+                .modify(|_, w| w.cpol().bit(polarity == Polarity::IdleHigh))
         }
 
         /// Clock phase
         #[inline]
-        fn set_clock_phase(phase: ClockPhase) {
+        fn set_clock_phase(phase: embedded_hal::spi::Phase) {
             Self::block()
                 .cr1
-                .modify(|_, w| w.cpha().bit(phase == ClockPhase::Hight))
+                .modify(|_, w| w.cpha().bit(phase == Phase::CaptureOnSecondTransition))
         }
 
         /// Slave fast mode enable

--- a/src/spi/mod.rs
+++ b/src/spi/mod.rs
@@ -12,7 +12,7 @@ use crate::mode::Mode;
 use core::marker::PhantomData;
 use embassy_hal_internal::{into_ref, Peripheral, PeripheralRef};
 
-use embedded_hal_027::spi;
+use embedded_hal::spi::{Phase, Polarity};
 use types::*;
 
 pub use master::Master;
@@ -67,19 +67,8 @@ impl<'d, T: Instance, M: Mode> AnySpi<'d, T, M> {
         nss: Option<PeripheralRef<'d, AnyPin>>,
         config: Config,
     ) -> Result<Self, Error> {
-        let phase = if config.mode.phase == spi::Phase::CaptureOnFirstTransition {
-            ClockPhase::Low
-        } else {
-            ClockPhase::Hight
-        };
-        let polarity = if config.mode.polarity == spi::Polarity::IdleLow {
-            ClockPolarity::Low
-        } else {
-            ClockPolarity::Hight
-        };
-
-        T::set_clock_phase(phase);
-        T::set_clock_polarity(polarity);
+        T::set_clock_phase(config.mode.phase);
+        T::set_clock_polarity(config.mode.polarity);
         T::set_frame_format(config.bit_order);
         T::set_baud_rate_div(config.baud_rate_div);
 
@@ -105,7 +94,7 @@ impl<'d, T: Instance, M: Mode> AnySpi<'d, T, M> {
 
         sck.set_instance_af(
             Speed::VeryHigh,
-            if config.mode.polarity == spi::Polarity::IdleLow {
+            if config.mode.polarity == Polarity::IdleLow {
                 PinIoType::PullDown
             } else {
                 PinIoType::PullUp
@@ -169,7 +158,7 @@ pub struct Rx<'d, T: Instance, M: Mode> {
 }
 
 pub struct Config {
-    pub mode: spi::Mode,
+    pub mode: embedded_hal::spi::Mode,
     pub bit_order: BitOrder,
     pub baud_rate_div: BaudRateDiv,
     pub data_len: DataLength,

--- a/src/spi/types.rs
+++ b/src/spi/types.rs
@@ -83,24 +83,6 @@ pub enum Rule {
     Master = 1,
 }
 
-/// Clock polarity
-#[derive(PartialEq, Clone, Copy)]
-pub enum ClockPolarity {
-    /// 0: CK to 0 when idle
-    Low = 0,
-    /// 1: CK to 1 when idle
-    Hight = 1,
-}
-
-/// Clock phase
-#[derive(PartialEq, Clone, Copy)]
-pub enum ClockPhase {
-    /// 0: The first clock transition is the first data capture edge
-    Low = 0,
-    /// 1: The second clock transition is the first data capture edge
-    Hight = 1,
-}
-
 /// Slave fast mode enable
 #[derive(PartialEq)]
 pub enum SlaveSpeedMode {
@@ -114,7 +96,7 @@ pub enum SlaveSpeedMode {
 #[derive(PartialEq)]
 pub enum DataLength {
     /// 0: 8-bit data frame transmission
-    Lenght8 = 0,
+    Length8 = 0,
     /// 1: 16-bit data frame transmission
     Length16 = 1,
 }


### PR DESCRIPTION
This pull request introduces the following changes:

- SPI Refactor: Adopts embedded-hal 1.0.0 SPI Phase and Polarity structures, removing custom structures for improved standardization and compatibility.
- I2C Implementation: Adds support for the embedded-hal 1.0.0 I2c trait in the Master structure.
- Dependencies Refactor: Rearranges the dependency list, separating dependencies and dev-dependencies for improved clarity and maintainability.
- CI Improvements: Fixes the adc_block_interrupt_closure example and ensures all examples are built and tested under CI to maintain quality and functionality.

The `display-interface` and `display-interface-i2c` dependencies will be updated once `ssd1309` crate supports new version of `display-interface` which implements `embedded-hal` 1.0.0. Ref: https://github.com/antonok-edm/ssd1309/pull/10